### PR TITLE
fix: stabilize plugin management interactions

### DIFF
--- a/docs/plugin-development.md
+++ b/docs/plugin-development.md
@@ -1,0 +1,295 @@
+# 插件系统开发文档
+
+本篇文档介绍 Hydrogen Music 新增的前端插件系统，包括目录结构、插件生命周期、上下文能力以及调试方式。所有内容均基于 Vue 3 + Vite 构建环境。
+
+## 目录结构
+
+```
+src/
+└── plugins/
+    ├── pluginManager.js   # 插件运行时与生命周期管理
+    └── modules/           # 每个插件一个文件，按需继续划分子目录
+        ├── audioEffectsPlugin.js
+        └── lyricVisualizerPlugin.js
+```
+
+- `pluginManager.js`：提供 `PluginManager` 类和 `createPluginManager` 工厂方法，负责加载插件、管理生命周期、分发钩子事件。
+- `modules/`：放置所有插件定义。新插件只需在该目录（或子目录）内创建一个 `*.js` 文件并导出插件对象即可。
+
+> 💡 **自动导入机制**：`createPluginManager` 内部使用 `import.meta.glob('./modules/**/*.js', { eager: true })` 扫描 `modules` 目录并在构建阶段自动导入所有插件文件。新增插件只要放入该目录，Vite 即会在下一次热更新或重新构建时将其打包并交给插件管理器注册，无需手动改动入口代码。
+
+## 插件定义
+
+每个插件文件需要默认导出一个对象，推荐结构如下：
+
+```js
+export default {
+  name: 'unique-name',        // 必填，全局唯一的插件名
+  version: '1.0.0',           // 可选，语义化版本号
+  description: '描述信息',    // 可选，插件说明
+  author: '作者',             // 可选
+  enabled: true,              // 可选，默认 true；设为 false 则不会自动加载
+  async setup(context) {
+    // 在这里编写插件逻辑
+    return () => { /* 可选的卸载清理函数 */ }
+  }
+}
+```
+
+### setup(context)
+
+`setup` 会在应用启动时由插件管理器调用，并接收一个 `context` 对象，包含以下能力：
+
+| 字段 | 类型 | 说明 |
+| ---- | ---- | ---- |
+| `app` | `App` | Vue 应用实例，可用于注册全局组件、指令等 |
+| `router` | `Router \| null` | Vue Router 实例（如有需要可进行路由扩展） |
+| `pinia` | `Pinia \| null` | Pinia 根实例，可用于注册 store 或访问全局状态 |
+| `manager` | `PluginManager` | 插件管理器本体，可进一步调用 `activatePlugin` 等方法 |
+| `hooks` | `PluginHooks` | 钩子系统，包含 `on`、`off`、`emit` 三个方法 |
+| `plugin` | `PluginMeta` | 当前插件的运行时元信息（包含 `name`、`origin`、`enabled` 等字段） |
+| `assets` | `{ list(): string[]; has(path): boolean; read(path, options?) }` | 便捷访问插件包内的静态资源 |
+
+`setup` 可以是同步或异步函数；若返回一个函数，该函数会在插件被卸载时执行用于清理资源。
+
+当插件以 `.hym` 包的形式安装时，可通过 `context.assets` 读取打包内的文件。例如：
+
+```js
+const text = await context.assets.read('templates/help.md')
+const config = await context.assets.read('config/options.json', { type: 'json' })
+```
+
+`assets.read` 默认返回字符串内容，`options.type` 支持 `text`、`json`、`arrayBuffer` 与 `base64`。`assets.list()` 可以查看所有可用的文件路径。
+
+## 插件包（`.hym`）规范
+
+Hydrogen Music 支持将插件打包成自定义的 `.hym` 文件，便于分发与导入。该格式本质上是一个 ZIP 压缩包，需要满足以下约定：
+
+| 项目 | 说明 |
+| --- | --- |
+| 文件扩展名 | 固定为 `.hym` |
+| 必备文件 | `manifest.json`（插件元数据）与入口文件 `index.js`，也可在 manifest 中通过 `main` 指向其他 JS/JSON 入口 |
+| manifest 字段 | 建议提供 `name`、`displayName`、`version`、`description`、`author` 等信息，`name` 会作为插件唯一标识 |
+| 资源文件 | 可按需附带任意静态资源，运行时可通过 `context.assets` 访问 |
+
+导入 `.hym` 文件时，渲染进程会解析并校验 manifest，然后将全部文件交由 Electron 主进程解压。默认情况下，解压后的内容会写入
+`app.getPath('userData')/plugins/installed/<插件名>-<时间戳>`；如果用户在设置页或运行时代码中指定了自定义的插件存储目录，则会保存到该路径
+下的唯一子文件夹中。插件入口脚本会被动态导入，运行时上下文可以立即访问随包提供的资源。卸载插件或彻底移除时，对应目录也会被删除；重启
+应用后会从该目录重新加载插件，无需再次手动导入。
+
+> ℹ️ 入口脚本需要导出标准的插件对象。可以直接使用编译后的 `.js`/`.mjs` 模块或 JSON 配置；若希望提供 `.vue` 组件，请提前通过构建流程
+> 输出可直接运行的 JavaScript。
+
+设置页的“导入插件”区块同时支持拖拽 `.hym` 文件与点击按钮选择文件。导入成功后会展示插件来源标签（内置插件 / 插件包），并可继续打开插件声
+明的二级设置入口。
+
+## 钩子（Hook）系统
+
+插件可以通过 `context.hooks` 订阅或触发自定义事件，实现插件间通信或监听应用生命周期。
+
+- `hooks.on(name, handler)`：订阅钩子事件，返回取消订阅函数。
+- `hooks.off(name, handler)`：取消订阅。
+- `hooks.emit(name, payload)`：主动触发钩子事件，支持异步处理，返回 `Promise`。
+
+应用内置的生命周期钩子：
+
+| 钩子名 | 触发时机 |
+| ------ | -------- |
+| `app:created` | 所有插件加载完毕后触发（可能是异步过程）。 |
+| `app:mounted` | Vue 应用完成挂载后触发。 |
+| `app:ready` | 应用完成初始化流程（`init()` 执行）后触发。 |
+
+插件也可以自定义其他钩子，约定名称即可。
+
+## 插件管理 API
+
+`createPluginManager` 会在 `src/main.js` 中初始化，并通过 `app.config.globalProperties.$plugins` 暴露给 Vue 实例与组件。
+
+可用方法：
+
+- `listPlugins()`：返回当前已注册插件的元信息数组。
+- `activatePlugin(name)`：手动激活指定插件。
+- `deactivatePlugin(name)`：停用指定插件，并调用其卸载函数。
+- `emitHook(name, payload)`：从应用层触发钩子事件。
+- `enablePlugin(name)` / `disablePlugin(name)`：更新插件启用状态，并自动触发激活/卸载流程，同时持久化到插件设置存储中；如插件此前被删除，这两个方法会先自动恢复模块再执行后续操作。
+- `removePlugin(name, options?)`：移除可删除的插件。默认仅在设置中标记为已删除，传入 `{ forgetState: true }` 会同时删除插件存档目录与设置，彻底清除相关记录。
+  所有内置插件（例如歌词可视化与音效增强）同样标记为可删除，方便调试或替换。
+- `restorePlugin(name)`：在插件被标记删除后重新恢复，便于调试临时停用的插件。
+- `exportSettings()` / `importSettings(payload, options?)`：导出或导入插件启用/删除等状态。`importSettings` 默认会同步激活状态，可通过 `options.syncActivation = false` 延迟处理。
+- `openPluginSettings(name)`：触发插件声明的二级设置入口。当插件提供设置描述时，设置页会自动渲染对应按钮。
+- `importPluginPackage(file, options?)`：从 `.hym` 插件包安装或更新插件模块，默认会立即启用并在设置存储中记录解压目录与 manifest 信息；
+  插件文件会解压到当前生效的插件存储目录，后续重启会自动从磁盘恢复。
+- `listPluginAssets(name)` / `readPluginAsset(name, path, options?)`：访问插件包随附的文件资源，`options.type` 支持 `text`、`json`、`arrayBuffer` 与 `base64`，便于在运行时加载额外的配置或模板。
+- `ensurePackagesRestored()`：返回一个 Promise，在所有持久化的插件包被重新加载后 resolve，适合在界面初始化时等待插件就绪。
+- `getPackageRootDirectory(options?)`：获取当前插件包存储目录的绝对路径，便于在调试日志或界面上显示。
+- `setPackageRootDirectory(directory)`：调整插件包的存储位置，Electron 主进程会在保持既有插件的情况下迁移文件夹；若提供的路径与当前相同，则不会重复移动。
+
+设置页在首次启用任意插件时都会弹出“目前该功能正在测试中，可能出现 BUG，确认开启？”提示，用户确认后会在插件状态中记录 `experimentalAck`
+字段，后续无需重复提醒。
+
+### 插件二级设置入口
+
+若插件需要在设置页中提供额外配置，可在定义对象中声明 `settings` 属性：
+
+```js
+export default {
+  name: 'example',
+  settings: {
+    label: '打开高级配置',
+    route: { name: 'plugin-example-settings' }
+  }
+}
+```
+
+支持的写法：
+
+- `settings.route`：传入 `router.push` 所需的对象或返回该对象的函数。
+- `settings.path`：直接指定路由路径（或返回路径的函数）。
+- `settings.open(context)`：完全自定义打开行为，`context` 与 `setup` 一致。
+- `settings.href`：指定一个链接地址（或返回地址的函数），会在新窗口中打开。
+
+也可以直接提供顶层 `openSettings(context)` 函数，等价于 `settings.open`。按钮文案默认为“插件设置”，可通过 `settings.label` 或 `settingsLabel` 字段覆盖。
+
+
+### 导入插件设置
+
+`exportSettings()` 会返回如下结构的普通对象，可序列化为 JSON 文件以便备份或迁移：
+
+```json
+{
+  "plugins": {
+    "audio-effects": { "enabled": true, "removed": false, "experimentalAck": true },
+    "lyric-visualizer": { "enabled": true, "removed": false },
+    "my-package-plugin": {
+      "enabled": true,
+      "removed": false,
+      "package": {
+        "directory": "C:/Users/<you>/AppData/Roaming/Hydrogen Music/plugins/installed/my-package-plugin-nf42r8",
+        "directoryName": "my-package-plugin-nf42r8",
+        "entry": "index.js",
+        "files": ["manifest.json", "index.js", "assets/config.json"],
+        "manifest": { "name": "my-package-plugin", "displayName": "示例插件", "version": "1.0.0" }
+      }
+    }
+  }
+}
+```
+
+在另一环境恢复时，先读取该 JSON，再传入 `importSettings`：
+
+```js
+import settings from './plugin-settings.json'
+
+await pluginManager.importSettings(settings)
+```
+
+若是通过文件选择器或网络请求获取到字符串内容，则需要先 `JSON.parse`：
+
+```js
+const fileContent = await file.text()
+const payload = JSON.parse(fileContent)
+await pluginManager.importSettings(payload)
+```
+
+如暂不希望立即激活或停用插件，可调用 `pluginManager.importSettings(payload, { syncActivation: false })`，稍后再按需执行 `enablePlugin` / `disablePlugin`。
+
+若某个插件来源于 `.hym` 包，导出的 JSON 会在对应条目下包含 `package` 字段。Electron 环境下会记录解压后的 `directory`、`directoryName`、`entry`、`files`
+等信息；其中 `directoryName` 表示插件在存储目录中的文件夹名称，便于在用户调整存储路径时重写绝对地址。如果当前平台不支持磁盘持久化，则会退化为 `archive`（Base64）形式。`importSettings` 会优先尝试使用目录恢复，若不存在则回退至归档数据，确保插件在新环境中可以重新加载。
+
+在 Vue 组件中可以通过 `this.$plugins` 访问这些能力。
+
+## 插件包（.hym）格式
+
+除了在源码中维护插件模块，也可以通过“插件包”在运行时动态安装。Hydrogen Music 约定使用 `.hym` 扩展名的 Zip 压缩文件，内部结构如下：
+
+```
+my-plugin.hym
+├─ manifest.json      # 插件清单，描述名称、版本、入口文件等
+├─ index.js           # 插件入口，可以是 ES Module（推荐）或 JSON
+└─ assets/...         # 其他资源文件，运行时可通过 context.assets 访问
+```
+
+### manifest.json 字段
+
+```json
+{
+  "name": "my-plugin",
+  "displayName": "示例插件",
+  "version": "1.0.0",
+  "description": "演示如何通过 .hym 安装插件",
+  "author": "Hydrogen", 
+  "main": "index.js"    // 可省略，默认 index.js；也支持 .json 入口
+}
+```
+
+- `name` 必填且全局唯一。
+- `main` 指向插件入口文件，支持 `.js` 或 `.mjs` 模块；若指向 `.json`，系统会自动解析为插件对象。
+- 其余字段会被同步到插件元信息中，显示在设置界面。
+
+### 入口文件示例
+
+```js
+export default {
+  name: 'my-plugin',
+  description: '通过 .hym 导入的插件',
+  setup({ hooks }) {
+    hooks.emit('example:ready')
+    return () => {
+      console.log('my-plugin disabled')
+    }
+  }
+}
+```
+
+### 打包与导入
+
+1. 将清单、入口文件及附属资源打包为 Zip，推荐使用“存储”模式（不压缩）以获得最佳兼容性；若使用 Deflate，运行环境需要支持 `DecompressionStream`。
+2. 将扩展名改为 `.hym`。
+3. 在设置页的“导入插件”区块中拖拽或选择 `.hym` 文件，或在代码里调用 `pluginManager.importPluginPackage(file)`。
+
+导入成功后，插件会出现在设置页面，可像内置插件一样启用、禁用或删除。通过 `context.assets` 可以读取包内的其他文件，例如 Vue 组件模板或国际化文本。插件包会被解压到 `plugins/installed` 目录，后续重启会自动加载。
+
+### 插件设置存储
+
+插件管理器会通过 `PluginSettingsStore` 自动记住插件的启用、禁用和删除状态，默认使用浏览器的 `localStorage`（Electron 版本也适用）。
+
+- 自定义存储：可以在创建插件管理器时通过 `createPluginManager(app, { storage, settingsKey })` 传入实现了 `getItem` / `setItem` 的存储适配器或自定义 key。
+- 导入/导出：借助上文的 `exportSettings` 与 `importSettings`，可以轻松备份或迁移插件设置。
+- 删除策略：`removePlugin(name)` 会停止插件并在设置中打上删除标记；若想彻底移除并遗忘该插件，传入 `{ forgetState: true }`。
+
+## 默认插件示例
+
+Hydrogen Music 默认提供两个可以直接参考的插件模块：
+
+### 歌词音频可视化（`lyricVisualizerPlugin.js`）
+
+- **功能**：在歌词界面绘制实时频谱动画，并提供柱状/圆环样式、采样频段、透明度等十余项视觉参数。插件会在设置页内注册“歌词音频可视化”二级入口（路由：`/plugins/lyric-visualizer`），相关配置逻辑全部封装在 `src/plugins/views/LyricVisualizerSettings.vue` 中。
+- **生命周期**：启用后会保持歌词可视化状态；停用或删除时会重置 `playerStore` 内的相关字段，避免残留配置影响其他功能。
+- **参考价值**：演示了插件如何注册独立路由、在设置页声明按钮，并与 Pinia store 协同维护大量 UI 交互。
+
+### 音效增强（`audioEffectsPlugin.js`）
+
+- **功能**：基于 Howler 的 Web Audio 管线，为播放器提供低音、高音、存在感、立体声宽度、空间混响及输出增益等多项音色调节。默认启用并提供 `audio-effects` 插件设置路由 `/plugins/audio-effects`，界面位于 `src/plugins/views/AudioEffectsSettings.vue`，已更新为与设置页统一的视觉风格并新增返回按钮。
+- **技术要点**：插件在 `setup` 中构建一套 `Gain`、`BiquadFilter`、`Delay`、`Convolver`、`ChannelSplitter`/`ChannelMerger` 节点链路，同时通过响应式状态向设置页面暴露调节参数；所有数值会持久化到插件设置存储中。
+- **参考价值**：展示了如何安全地接入 Howler 提供的音频上下文、封装共享状态、保存自定义偏好，并扩展现有插件以提供更丰富的音效体验。
+
+两个示例都设置了 `removable: true`，用户可以在插件管理界面删除或重新导入它们。开发者也可以复制这些文件作为脚手架，快速搭建具备路由、设置和持久化能力的高级插件。
+
+## 调试建议
+
+1. 开发期间保持 `npm run dev` 运行，Vite 会热重载插件文件。
+2. 在浏览器控制台或 Electron 调试工具内查看日志，确认插件加载、钩子触发是否符合预期。
+3. 如需在运行时动态控制插件，可以在控制台访问 `window.__HYDROGEN_APP__.plugins`（或通过组件内的 `this.$plugins`）。
+
+## 可以实现哪些类型的插件？
+
+插件的能力由 `setup(context)` 提供的上下文决定：你可以直接访问 Vue 应用、路由、Pinia Store 以及钩子系统。借助这些入口，常见的扩展类型包括：
+
+- **第三方 API 集成**：在 `setup` 中发起网络请求、监听钩子并将返回的数据写入 Pinia 或触发自定义事件，从而为应用增加歌词、榜单、推荐算法等服务。
+- **主题/样式扩展**：利用 `context.app` 注册全局组件或指令，或者直接注入自定义样式表，以实现暗色主题、季节皮肤等 UI 定制。也可以在钩子中监听应用主题切换，动态调整外观。
+- **音频处理与混音辅助**：插件可与现有音频播放逻辑通过钩子交互，在播放事件上挂载处理器、收集电平数据并渲染自定义面板，或调用 Web Audio API 追加混音与效果链。
+- **工作流自动化**：结合 `hooks.emit` 与 `hooks.on` 建立跨插件通信，编排定时任务、批量下载、播放列表同步等高级功能。
+
+总之，只要逻辑可以在浏览器/Electron 环境运行，就能封装成插件。若遇到需要持久化的状态，可通过 `PluginSettingsStore` 存储启用信息或自行写入其他后端服务。
+
+祝开发愉快！

--- a/src/electron/preload.js
+++ b/src/electron/preload.js
@@ -157,6 +157,13 @@ function openNeteaseLogin() {
 function clearLoginSession() {
     return ipcRenderer.invoke('clear-login-session')
 }
+
+const pluginInstallPackage = payload => ipcRenderer.invoke('plugins:install-package', payload)
+const pluginRemovePackage = payload => ipcRenderer.invoke('plugins:remove-package', payload)
+const pluginReadFile = payload => ipcRenderer.invoke('plugins:read-file', payload)
+const pluginListFiles = payload => ipcRenderer.invoke('plugins:list-files', payload)
+const pluginGetRoot = () => ipcRenderer.invoke('plugins:get-root')
+const pluginSetRoot = payload => ipcRenderer.invoke('plugins:set-root', payload)
 contextBridge.exposeInMainWorld('windowApi', {
     windowMin,
     windowMax,
@@ -248,4 +255,12 @@ contextBridge.exposeInMainWorld('electronAPI', {
     setLyricWindowAspectRatio: (aspectRatio) => ipcRenderer.send('set-lyric-window-aspect-ratio', { aspectRatio }),
     getLyricWindowContentBounds: () => ipcRenderer.invoke('get-lyric-window-content-bounds'),
     moveLyricWindowContentTo: (x, y, width, height) => ipcRenderer.send('move-lyric-window-content-to', { x, y, width, height }),
+    plugins: {
+        installPackage: pluginInstallPackage,
+        removePackage: pluginRemovePackage,
+        readFile: pluginReadFile,
+        listFiles: pluginListFiles,
+        getRoot: pluginGetRoot,
+        setRoot: pluginSetRoot,
+    },
 })

--- a/src/main.js
+++ b/src/main.js
@@ -11,14 +11,33 @@ import './assets/css/fonts.css'
 import './assets/css/theme.css'
 import { initTheme } from './utils/theme'
 import { initMediaSession } from './utils/mediaSession'
+import { createPluginManager } from './plugins/pluginManager'
 const app = createApp(App)
 app.use(router)
 app.use(pinia)
 app.directive('lazy', lazy)
+
+const pluginManager = createPluginManager(app, { router, pinia })
+app.config.globalProperties.$plugins = pluginManager
+
 // Initialize theme before app renders
 initTheme()
-app.mount('#app')
+
+pluginManager.installAll().then(() => {
+  pluginManager.emitHook('app:created', { app })
+})
+
+const vm = app.mount('#app')
+pluginManager.emitHook('app:mounted', { app, vm })
+if (typeof window !== 'undefined') {
+  window.__HYDROGEN_APP__ = {
+    app,
+    vm,
+    plugins: pluginManager
+  }
+}
 init()
+pluginManager.emitHook('app:ready', { app })
 // Initialize System Media Transport Controls (Windows SMTC / macOS Now Playing)
 try { initMediaSession() } catch (_) {}
 

--- a/src/plugins/modules/audioEffectsPlugin.js
+++ b/src/plugins/modules/audioEffectsPlugin.js
@@ -1,0 +1,403 @@
+import { Howler } from 'howler'
+import { reactive } from 'vue'
+
+const ROUTE_NAME = 'plugin-audio-effects-settings'
+const BASS_MIN = -12
+const BASS_MAX = 12
+const TREBLE_MIN = -12
+const TREBLE_MAX = 12
+const PRESENCE_MIN = -12
+const PRESENCE_MAX = 12
+const AMBIENCE_MIN = 0
+const AMBIENCE_MAX = 1
+const WIDTH_MIN = 0
+const WIDTH_MAX = 2
+const OUTPUT_GAIN_MIN = -12
+const OUTPUT_GAIN_MAX = 6
+
+const DEFAULTS = Object.freeze({
+  bypass: false,
+  bass: 4,
+  treble: 2,
+  presence: 1,
+  ambience: 0.2,
+  stereoWidth: 1.1,
+  outputGain: 0
+})
+
+export const audioEffectsState = reactive({
+  available: typeof Howler !== 'undefined' ? Howler.usingWebAudio : false,
+  bypass: DEFAULTS.bypass,
+  bass: DEFAULTS.bass,
+  treble: DEFAULTS.treble,
+  presence: DEFAULTS.presence,
+  ambience: DEFAULTS.ambience,
+  stereoWidth: DEFAULTS.stereoWidth,
+  outputGain: DEFAULTS.outputGain,
+  active: false
+})
+
+let managerRef = null
+let chain = null
+let connected = false
+
+function createImpulseResponse(context) {
+  const length = context.sampleRate * 0.2
+  const impulse = context.createBuffer(2, length, context.sampleRate)
+  for (let channel = 0; channel < impulse.numberOfChannels; channel += 1) {
+    const data = impulse.getChannelData(channel)
+    for (let i = 0; i < length; i += 1) {
+      data[i] = (Math.random() * 2 - 1) * Math.pow(1 - i / length, 3)
+    }
+  }
+  return impulse
+}
+
+function dbToGain(db) {
+  const value = clamp(db, OUTPUT_GAIN_MIN, OUTPUT_GAIN_MAX)
+  return Math.pow(10, value / 20)
+}
+
+function ensureChain() {
+  if (!audioEffectsState.available) return null
+  if (!Howler.masterGain || !Howler.ctx) return null
+  if (chain) return chain
+
+  const context = Howler.ctx
+  const input = context.createGain()
+
+  const bassFilter = context.createBiquadFilter()
+  bassFilter.type = 'lowshelf'
+  bassFilter.frequency.value = 200
+
+  const presenceFilter = context.createBiquadFilter()
+  presenceFilter.type = 'peaking'
+  presenceFilter.frequency.value = 1250
+  presenceFilter.Q.value = 1.25
+  presenceFilter.gain.value = audioEffectsState.presence
+
+  const trebleFilter = context.createBiquadFilter()
+  trebleFilter.type = 'highshelf'
+  trebleFilter.frequency.value = 3500
+
+  const compressor = context.createDynamicsCompressor()
+  compressor.threshold.value = -18
+  compressor.knee.value = 18
+  compressor.ratio.value = 3
+  compressor.attack.value = 0.005
+  compressor.release.value = 0.25
+
+  const widthSplitter = context.createChannelSplitter(2)
+  const widthLeftDirect = context.createGain()
+  const widthLeftCross = context.createGain()
+  const widthRightDirect = context.createGain()
+  const widthRightCross = context.createGain()
+  const widthMerger = context.createChannelMerger(2)
+
+  const outputGain = context.createGain()
+  outputGain.gain.value = dbToGain(audioEffectsState.outputGain)
+
+  const dryGain = context.createGain()
+  dryGain.gain.value = 1
+
+  const ambienceSend = context.createGain()
+  ambienceSend.gain.value = 1
+
+  const wetGain = context.createGain()
+  wetGain.gain.value = audioEffectsState.ambience
+
+  const delay = context.createDelay(0.35)
+  delay.delayTime.value = 0.03
+
+  const feedback = context.createGain()
+  feedback.gain.value = 0.2
+
+  const convolver = context.createConvolver()
+  try {
+    convolver.buffer = createImpulseResponse(context)
+  } catch (error) {
+    console.warn('[AudioEffectsPlugin] Failed to generate impulse response:', error)
+  }
+
+  const output = context.createGain()
+
+  input.connect(bassFilter)
+  bassFilter.connect(presenceFilter)
+  presenceFilter.connect(trebleFilter)
+  trebleFilter.connect(compressor)
+  compressor.connect(widthSplitter)
+
+  widthSplitter.connect(widthLeftDirect, 0)
+  widthSplitter.connect(widthRightCross, 0)
+  widthSplitter.connect(widthRightDirect, 1)
+  widthSplitter.connect(widthLeftCross, 1)
+
+  widthLeftDirect.connect(widthMerger, 0, 0)
+  widthLeftCross.connect(widthMerger, 0, 0)
+  widthRightDirect.connect(widthMerger, 0, 1)
+  widthRightCross.connect(widthMerger, 0, 1)
+
+  widthMerger.connect(outputGain)
+  outputGain.connect(dryGain)
+  dryGain.connect(output)
+
+  widthMerger.connect(ambienceSend)
+  ambienceSend.connect(delay)
+  delay.connect(feedback)
+  feedback.connect(delay)
+  delay.connect(convolver)
+  convolver.connect(wetGain)
+  wetGain.connect(output)
+
+  chain = {
+    input,
+    bassFilter,
+    presenceFilter,
+    trebleFilter,
+    compressor,
+    width: {
+      splitter: widthSplitter,
+      leftDirect: widthLeftDirect,
+      leftCross: widthLeftCross,
+      rightDirect: widthRightDirect,
+      rightCross: widthRightCross,
+      merger: widthMerger
+    },
+    outputGain,
+    dryGain,
+    ambienceSend,
+    wetGain,
+    delay,
+    feedback,
+    convolver,
+    output
+  }
+
+  return chain
+}
+
+function disconnectChain() {
+  if (!connected) return
+  try {
+    Howler.masterGain.disconnect()
+  } catch (_) {
+    // ignore
+  }
+  try {
+    if (chain?.input) {
+      chain.input.disconnect()
+    }
+    if (chain?.output) {
+      chain.output.disconnect()
+    }
+  } catch (_) {
+    // ignore
+  }
+  try {
+    if (Howler.ctx) {
+      Howler.masterGain.connect(Howler.ctx.destination)
+    }
+  } catch (_) {
+    // ignore
+  }
+  connected = false
+  audioEffectsState.active = false
+}
+
+function applyChainSettings() {
+  if (!chain) return
+  chain.bassFilter.gain.value = audioEffectsState.bass
+  chain.presenceFilter.gain.value = audioEffectsState.presence
+  chain.trebleFilter.gain.value = audioEffectsState.treble
+  chain.wetGain.gain.value = audioEffectsState.ambience
+  chain.outputGain.gain.value = dbToGain(audioEffectsState.outputGain)
+  applyStereoWidth()
+}
+
+function applyStereoWidth() {
+  if (!chain?.width) return
+  const width = clamp(audioEffectsState.stereoWidth, WIDTH_MIN, WIDTH_MAX)
+  const direct = 0.5 * (1 + width)
+  const cross = 0.5 * (1 - width)
+  chain.width.leftDirect.gain.value = direct
+  chain.width.rightDirect.gain.value = direct
+  chain.width.leftCross.gain.value = cross
+  chain.width.rightCross.gain.value = cross
+}
+
+function connectChain() {
+  if (!audioEffectsState.available || audioEffectsState.bypass) {
+    disconnectChain()
+    return
+  }
+  const nodes = ensureChain()
+  if (!nodes) {
+    audioEffectsState.active = false
+    return
+  }
+  if (!connected) {
+    try {
+      Howler.masterGain.disconnect()
+    } catch (_) {
+      // ignore
+    }
+    try {
+      nodes.output.disconnect()
+    } catch (_) {
+      // ignore
+    }
+    try {
+      Howler.masterGain.connect(nodes.input)
+      nodes.output.connect(Howler.ctx.destination)
+      connected = true
+      audioEffectsState.active = true
+    } catch (error) {
+      console.warn('[AudioEffectsPlugin] Failed to connect effect chain:', error)
+      connected = false
+      audioEffectsState.active = false
+    }
+  }
+  applyChainSettings()
+}
+
+function clamp(value, min, max) {
+  const numeric = Number(value)
+  if (Number.isNaN(numeric)) return min
+  return Math.min(max, Math.max(min, numeric))
+}
+
+function persistState() {
+  if (!managerRef?.settingsStore) return
+  try {
+    managerRef.settingsStore.setState('audio-effects', {
+      data: {
+        bypass: audioEffectsState.bypass,
+        bass: audioEffectsState.bass,
+        treble: audioEffectsState.treble,
+        presence: audioEffectsState.presence,
+        ambience: audioEffectsState.ambience,
+        stereoWidth: audioEffectsState.stereoWidth,
+        outputGain: audioEffectsState.outputGain
+      }
+    })
+  } catch (error) {
+    console.warn('[AudioEffectsPlugin] Failed to persist state:', error)
+  }
+}
+
+function loadState(manager) {
+  const stored = manager?.settingsStore?.getState('audio-effects')
+  if (!stored?.data) return
+  const { bypass, bass, treble, ambience, presence, stereoWidth, outputGain } = stored.data
+  audioEffectsState.bypass = Boolean(bypass)
+  audioEffectsState.bass = clamp(bass ?? DEFAULTS.bass, BASS_MIN, BASS_MAX)
+  audioEffectsState.treble = clamp(treble ?? DEFAULTS.treble, TREBLE_MIN, TREBLE_MAX)
+  audioEffectsState.presence = clamp(presence ?? DEFAULTS.presence, PRESENCE_MIN, PRESENCE_MAX)
+  audioEffectsState.ambience = clamp(ambience ?? DEFAULTS.ambience, AMBIENCE_MIN, AMBIENCE_MAX)
+  audioEffectsState.stereoWidth = clamp(stereoWidth ?? DEFAULTS.stereoWidth, WIDTH_MIN, WIDTH_MAX)
+  audioEffectsState.outputGain = clamp(outputGain ?? DEFAULTS.outputGain, OUTPUT_GAIN_MIN, OUTPUT_GAIN_MAX)
+}
+
+export function setAudioEffectsBypass(bypass) {
+  audioEffectsState.bypass = Boolean(bypass)
+  if (audioEffectsState.bypass) {
+    disconnectChain()
+  } else {
+    connectChain()
+  }
+  persistState()
+}
+
+export function setAudioEffectsBass(value) {
+  audioEffectsState.bass = clamp(value, BASS_MIN, BASS_MAX)
+  connectChain()
+  applyChainSettings()
+  persistState()
+}
+
+export function setAudioEffectsTreble(value) {
+  audioEffectsState.treble = clamp(value, TREBLE_MIN, TREBLE_MAX)
+  connectChain()
+  applyChainSettings()
+  persistState()
+}
+
+export function setAudioEffectsAmbience(value) {
+  audioEffectsState.ambience = clamp(value, AMBIENCE_MIN, AMBIENCE_MAX)
+  connectChain()
+  applyChainSettings()
+  persistState()
+}
+
+export function setAudioEffectsPresence(value) {
+  audioEffectsState.presence = clamp(value, PRESENCE_MIN, PRESENCE_MAX)
+  connectChain()
+  applyChainSettings()
+  persistState()
+}
+
+export function setAudioEffectsStereoWidth(value) {
+  audioEffectsState.stereoWidth = clamp(value, WIDTH_MIN, WIDTH_MAX)
+  connectChain()
+  applyChainSettings()
+  persistState()
+}
+
+export function setAudioEffectsOutputGain(value) {
+  audioEffectsState.outputGain = clamp(value, OUTPUT_GAIN_MIN, OUTPUT_GAIN_MAX)
+  connectChain()
+  applyChainSettings()
+  persistState()
+}
+
+export function resetAudioEffects() {
+  audioEffectsState.bypass = DEFAULTS.bypass
+  audioEffectsState.bass = DEFAULTS.bass
+  audioEffectsState.treble = DEFAULTS.treble
+  audioEffectsState.presence = DEFAULTS.presence
+  audioEffectsState.ambience = DEFAULTS.ambience
+  audioEffectsState.stereoWidth = DEFAULTS.stereoWidth
+  audioEffectsState.outputGain = DEFAULTS.outputGain
+  connectChain()
+  applyChainSettings()
+  persistState()
+}
+
+export default {
+  name: 'audio-effects',
+  displayName: '音效增强',
+  version: '1.1.0',
+  description: '提供低音、高音、存在感、立体声宽度与空间混响的综合音效调节。',
+  author: 'Hydrogen Music Team',
+  enabled: true,
+  removable: true,
+  settings: {
+    label: '打开音效设置',
+    route: { name: ROUTE_NAME }
+  },
+  async setup({ router, manager }) {
+    managerRef = manager ?? null
+    audioEffectsState.available = typeof Howler !== 'undefined' ? Howler.usingWebAudio : false
+    if (managerRef) {
+      loadState(managerRef)
+    }
+
+    if (router && !router.hasRoute(ROUTE_NAME)) {
+      router.addRoute({
+        path: '/plugins/audio-effects',
+        name: ROUTE_NAME,
+        component: () => import('../views/AudioEffectsSettings.vue')
+      })
+    }
+
+    connectChain()
+
+    return async () => {
+      disconnectChain()
+      if (router && router.hasRoute(ROUTE_NAME)) {
+        router.removeRoute(ROUTE_NAME)
+      }
+      managerRef = null
+    }
+  }
+}

--- a/src/plugins/modules/lyricVisualizerPlugin.js
+++ b/src/plugins/modules/lyricVisualizerPlugin.js
@@ -1,0 +1,66 @@
+import { usePlayerStore } from '../../store/playerStore'
+
+const ROUTE_NAME = 'plugin-lyric-visualizer-settings'
+
+export const lyricVisualizerDefaults = Object.freeze({
+  height: 220,
+  frequencyMin: 20,
+  frequencyMax: 8000,
+  transitionDelay: 0.75,
+  barCount: 48,
+  barWidth: 55,
+  color: 'black',
+  opacity: 100,
+  style: 'bars',
+  radialSize: 100,
+  radialOffsetX: 0,
+  radialOffsetY: 0
+})
+
+function resetLyricVisualizerState(pinia) {
+  if (!pinia) return
+  const playerStore = usePlayerStore(pinia)
+  playerStore.lyricVisualizer = false
+  playerStore.lyricVisualizerHeight = lyricVisualizerDefaults.height
+  playerStore.lyricVisualizerFrequencyMin = lyricVisualizerDefaults.frequencyMin
+  playerStore.lyricVisualizerFrequencyMax = lyricVisualizerDefaults.frequencyMax
+  playerStore.lyricVisualizerTransitionDelay = lyricVisualizerDefaults.transitionDelay
+  playerStore.lyricVisualizerBarCount = lyricVisualizerDefaults.barCount
+  playerStore.lyricVisualizerBarWidth = lyricVisualizerDefaults.barWidth
+  playerStore.lyricVisualizerColor = lyricVisualizerDefaults.color
+  playerStore.lyricVisualizerOpacity = lyricVisualizerDefaults.opacity
+  playerStore.lyricVisualizerStyle = lyricVisualizerDefaults.style
+  playerStore.lyricVisualizerRadialSize = lyricVisualizerDefaults.radialSize
+  playerStore.lyricVisualizerRadialOffsetX = lyricVisualizerDefaults.radialOffsetX
+  playerStore.lyricVisualizerRadialOffsetY = lyricVisualizerDefaults.radialOffsetY
+}
+
+export default {
+  name: 'lyric-visualizer',
+  displayName: '歌词可视化',
+  version: '1.0.0',
+  description: '在歌词区域展示实时音频频谱，并支持灵活的外观自定义。',
+  author: 'Hydrogen Music Team',
+  enabled: true,
+  removable: true,
+  settings: {
+    label: '打开歌词可视化设置',
+    route: { name: ROUTE_NAME }
+  },
+  async setup({ router, pinia }) {
+    if (router && !router.hasRoute(ROUTE_NAME)) {
+      router.addRoute({
+        path: '/plugins/lyric-visualizer',
+        name: ROUTE_NAME,
+        component: () => import('../views/LyricVisualizerSettings.vue')
+      })
+    }
+
+    return async () => {
+      if (router && router.hasRoute(ROUTE_NAME)) {
+        router.removeRoute(ROUTE_NAME)
+      }
+      resetLyricVisualizerState(pinia)
+    }
+  }
+}

--- a/src/plugins/pluginManager.js
+++ b/src/plugins/pluginManager.js
@@ -1,0 +1,1441 @@
+const DEFAULT_SCOPE = 'global'
+const DEFAULT_STORAGE_KEY = 'hydrogen.plugins.settings'
+const PACKAGE_EXTENSION = '.hym'
+const PACKAGE_MANIFEST_PATH = 'manifest.json'
+const PACKAGE_DEFAULT_MAIN = 'index.js'
+
+const textDecoder = typeof TextDecoder !== 'undefined' ? new TextDecoder('utf-8') : null
+
+function isPromiseLike(value) {
+  return value && typeof value.then === 'function'
+}
+
+function readText(bytes) {
+  if (!bytes) return ''
+  if (!textDecoder) {
+    throw new Error('当前环境不支持读取文本内容')
+  }
+  return textDecoder.decode(bytes)
+}
+
+function normalizePackagePath(path) {
+  if (!path) return ''
+  return String(path).replace(/^[./\\]+/, '').replace(/\\+/g, '/').trim()
+}
+
+function sanitizeRelativePath(path) {
+  const normalized = normalizePackagePath(path)
+  if (!normalized || normalized.includes('..')) {
+    throw new Error(`非法的文件路径：${path}`)
+  }
+  return normalized
+}
+
+function normalizePathString(path) {
+  if (!path) return ''
+  let normalized = String(path).replace(/\\+/g, '/').trim()
+  if (!normalized) return ''
+  if (normalized === '/') return '/'
+  const driveMatch = normalized.match(/^([A-Za-z]:)(\/.*)?$/)
+  if (driveMatch) {
+    const drive = `${driveMatch[1]}/`
+    const rest = driveMatch[2] ? driveMatch[2].replace(/^\/+/, '') : ''
+    normalized = drive + rest
+  }
+  normalized = normalized.replace(/\/+/g, '/')
+  if (/^[A-Za-z]:\/$/.test(normalized)) {
+    return normalized
+  }
+  if (normalized.endsWith('/') && normalized.length > 1) {
+    normalized = normalized.replace(/\/+$/, '')
+  }
+  return normalized
+}
+
+function normalizeComparablePath(path) {
+  return normalizePathString(path)
+}
+
+function joinPathSegments(base, child) {
+  const normalizedBase = normalizePathString(base)
+  const normalizedChild = normalizePathString(child)
+  if (!normalizedBase) return normalizedChild
+  if (!normalizedChild) return normalizedBase
+  if (normalizedBase === '/') {
+    return `/${normalizedChild.replace(/^\/+/, '')}`
+  }
+  if (/^[A-Za-z]:\/$/.test(normalizedBase)) {
+    return `${normalizedBase}${normalizedChild.replace(/^\/+/, '')}`
+  }
+  return `${normalizedBase.replace(/\/$/, '')}/${normalizedChild.replace(/^\/+/, '')}`.replace(/\/+/g, '/')
+}
+
+function extractDirectoryName(path) {
+  const normalized = normalizePathString(path)
+  if (!normalized) return ''
+  const segments = normalized.split('/')
+  return segments[segments.length - 1] || ''
+}
+
+function uint8ToBase64(view) {
+  if (!view) return ''
+  const buffer = view.buffer.slice(view.byteOffset, view.byteOffset + view.byteLength)
+  return arrayBufferToBase64(buffer)
+}
+
+function base64ToUint8(base64) {
+  const buffer = base64ToArrayBuffer(base64)
+  return new Uint8Array(buffer)
+}
+
+async function inflateRaw(data) {
+  if (typeof DecompressionStream !== 'function') {
+    throw new Error('当前环境不支持解压 Deflate，请使用存储模式创建插件包')
+  }
+  const stream = new Blob([data]).stream().pipeThrough(new DecompressionStream('deflate-raw'))
+  const buffer = await new Response(stream).arrayBuffer()
+  return new Uint8Array(buffer)
+}
+
+async function extractPackageEntries(arrayBuffer) {
+  const view = new DataView(arrayBuffer)
+  const length = view.byteLength
+  const files = new Map()
+  let offset = 0
+
+  while (offset + 30 <= length) {
+    const signature = view.getUint32(offset, true)
+
+    if (signature === 0x04034b50) {
+      const flags = view.getUint16(offset + 6, true)
+      if (flags & 0x0008) {
+        throw new Error('暂不支持带有数据描述符的插件包')
+      }
+
+      const compression = view.getUint16(offset + 8, true)
+      const compressedSize = view.getUint32(offset + 18, true)
+      const uncompressedSize = view.getUint32(offset + 22, true)
+      const nameLength = view.getUint16(offset + 26, true)
+      const extraLength = view.getUint16(offset + 28, true)
+
+      const nameStart = offset + 30
+      const dataStart = nameStart + nameLength + extraLength
+      const dataEnd = dataStart + compressedSize
+
+      if (dataEnd > length) {
+        throw new Error('插件包内容不完整，无法读取')
+      }
+
+      const rawName = new Uint8Array(arrayBuffer, nameStart, nameLength)
+      const filename = normalizePackagePath(readText(rawName))
+
+      const compressed = new Uint8Array(arrayBuffer, dataStart, compressedSize)
+      let fileData
+
+      if (compression === 0) {
+        fileData = new Uint8Array(compressed)
+      } else if (compression === 8) {
+        fileData = await inflateRaw(compressed)
+      } else {
+        throw new Error(`不支持的压缩算法：${compression}`)
+      }
+
+      if (uncompressedSize && fileData.length !== uncompressedSize) {
+        console.warn('[PluginManager] 解压后的文件长度与记录不一致，将以解压结果为准。')
+      }
+
+      if (filename) {
+        files.set(filename, fileData)
+      }
+
+      offset = dataEnd
+      continue
+    }
+
+    if (signature === 0x02014b50 || signature === 0x06054b50) {
+      break
+    }
+
+    offset += 1
+  }
+
+  return files
+}
+
+function arrayBufferToBase64(buffer) {
+  if (!buffer) return ''
+  let binary = ''
+  const bytes = new Uint8Array(buffer)
+  const chunkSize = 0x8000
+  for (let i = 0; i < bytes.length; i += chunkSize) {
+    const chunk = bytes.subarray(i, Math.min(i + chunkSize, bytes.length))
+    let segment = ''
+    for (let j = 0; j < chunk.length; j += 1) {
+      segment += String.fromCharCode(chunk[j])
+    }
+    binary += segment
+  }
+  if (typeof btoa === 'function') {
+    return btoa(binary)
+  }
+  if (typeof Buffer !== 'undefined') {
+    return Buffer.from(binary, 'binary').toString('base64')
+  }
+  throw new Error('当前环境不支持 Base64 编码')
+}
+
+function base64ToArrayBuffer(base64) {
+  if (!base64) return new ArrayBuffer(0)
+  let binary
+  if (typeof atob === 'function') {
+    binary = atob(base64)
+  } else if (typeof Buffer !== 'undefined') {
+    binary = Buffer.from(base64, 'base64').toString('binary')
+  } else {
+    throw new Error('当前环境不支持 Base64 解码')
+  }
+  const buffer = new ArrayBuffer(binary.length)
+  const bytes = new Uint8Array(buffer)
+  for (let i = 0; i < binary.length; i += 1) {
+    bytes[i] = binary.charCodeAt(i)
+  }
+  return buffer
+}
+
+function sanitizeManifest(manifest, fallbackName = '') {
+  if (!manifest || typeof manifest !== 'object') {
+    return { name: fallbackName }
+  }
+  const normalized = { ...manifest }
+  if (!normalized.name && fallbackName) {
+    normalized.name = fallbackName
+  }
+  return normalized
+}
+
+export class PluginSettingsStore {
+  constructor(options = {}) {
+    const { storageKey = DEFAULT_STORAGE_KEY, storage = null } = options
+    this.storageKey = storageKey
+    this.storage = storage ?? (typeof window !== 'undefined' ? window.localStorage : null)
+    this.state = { plugins: {} }
+    this._load()
+  }
+
+  _load() {
+    if (!this.storage) return
+    try {
+      const raw = this.storage.getItem(this.storageKey)
+      if (!raw) return
+      const parsed = JSON.parse(raw)
+      if (parsed && typeof parsed === 'object') {
+        const plugins = parsed.plugins
+        if (plugins && typeof plugins === 'object') {
+          this.state.plugins = { ...plugins }
+        }
+      }
+    } catch (error) {
+      console.warn('[PluginManager] Failed to parse stored plugin settings.', error)
+    }
+  }
+
+  _persist() {
+    if (!this.storage) return
+    try {
+      this.storage.setItem(this.storageKey, JSON.stringify(this.state))
+    } catch (error) {
+      console.warn('[PluginManager] Failed to persist plugin settings.', error)
+    }
+  }
+
+  getState(name) {
+    return this.state.plugins?.[name] ?? null
+  }
+
+  setState(name, patch) {
+    if (!name) return null
+    const next = {
+      ...(this.state.plugins?.[name] ?? {}),
+      ...(patch ?? {})
+    }
+    if (next.removed) {
+      next.enabled = false
+    }
+    if (!this.state.plugins || typeof this.state.plugins !== 'object') {
+      this.state.plugins = {}
+    }
+    this.state.plugins[name] = next
+    this._persist()
+    return next
+  }
+
+  deleteState(name) {
+    if (!name || !this.state.plugins) return
+    if (this.state.plugins[name]) {
+      delete this.state.plugins[name]
+      this._persist()
+    }
+  }
+
+  list() {
+    return { ...(this.state.plugins ?? {}) }
+  }
+
+  export() {
+    return JSON.parse(JSON.stringify(this.state))
+  }
+
+  import(payload, { merge = true } = {}) {
+    if (!payload || typeof payload !== 'object') return
+    const incoming = payload.plugins
+    if (!incoming || typeof incoming !== 'object') return
+    if (!merge) {
+      this.state.plugins = {}
+    }
+    this.state.plugins = {
+      ...(this.state.plugins ?? {}),
+      ...incoming
+    }
+    this._persist()
+  }
+}
+
+class HookRegistry {
+  constructor() {
+    this._hooks = new Map()
+  }
+
+  on(name, handler) {
+    if (typeof handler !== 'function') {
+      console.warn(`[PluginManager] Attempted to register non-function handler for hook "${name}".`)
+      return () => {}
+    }
+    if (!this._hooks.has(name)) {
+      this._hooks.set(name, new Set())
+    }
+    const handlers = this._hooks.get(name)
+    handlers.add(handler)
+    return () => this.off(name, handler)
+  }
+
+  off(name, handler) {
+    const handlers = this._hooks.get(name)
+    if (!handlers) return
+    handlers.delete(handler)
+    if (handlers.size === 0) {
+      this._hooks.delete(name)
+    }
+  }
+
+  async emit(name, payload, context) {
+    const handlers = this._hooks.get(name)
+    if (!handlers || handlers.size === 0) return []
+    const executions = []
+    handlers.forEach((handler) => {
+      try {
+        executions.push(Promise.resolve(handler(payload, context)))
+      } catch (error) {
+        console.error(`[PluginManager] Hook "${name}" handler failed:`, error)
+      }
+    })
+    return Promise.all(executions)
+  }
+}
+
+export class PluginManager {
+  constructor(app, options = {}) {
+    this.app = app
+    this.router = options.router ?? null
+    this.pinia = options.pinia ?? null
+    this.scope = options.scope ?? DEFAULT_SCOPE
+    this.plugins = new Map()
+    this.hooks = new HookRegistry()
+    this.settingsStore = options.settingsStore ?? new PluginSettingsStore({
+      storageKey: options.settingsKey,
+      storage: options.storage
+    })
+    this.moduleSources = new Map()
+    this.packageUrls = new Map()
+    this.packageRoot = null
+    this.packageRootPromise = null
+    this._restorePackagesPromise = null
+    this.getPackageRootDirectory().catch(() => {})
+    this._restorePackagesPromise = this._restorePersistedPackages()
+  }
+
+  _getPluginBridge() {
+    if (typeof window === 'undefined') return null
+    const bridge = window.electronAPI?.plugins ?? null
+    if (!bridge) return null
+    if (typeof bridge !== 'object') return null
+    return bridge
+  }
+
+  async _fetchPackageRoot(force = false) {
+    if (!force && this.packageRoot) {
+      return this.packageRoot
+    }
+    const bridge = this._getPluginBridge()
+    if (!bridge?.getRoot) {
+      return this.packageRoot ?? null
+    }
+    if (!force && this.packageRootPromise) {
+      return this.packageRootPromise
+    }
+    const task = (async () => {
+      try {
+        const result = await bridge.getRoot()
+        if (result?.directory) {
+          this.packageRoot = result.directory
+        }
+      } catch (error) {
+        console.warn('[PluginManager] 获取插件存储目录失败:', error)
+      }
+      const resolved = this.packageRoot ?? null
+      this.packageRootPromise = null
+      return resolved
+    })()
+    this.packageRootPromise = task
+    return task
+  }
+
+  async getPackageRootDirectory(options = {}) {
+    const { force = false } = options
+    const root = await this._fetchPackageRoot(force)
+    return root ?? null
+  }
+
+  _notePackageRoot(root) {
+    if (!root) return
+    const previous = normalizeComparablePath(this.packageRoot)
+    const next = normalizeComparablePath(root)
+    this.packageRoot = root
+    if (next && next !== previous) {
+      this._emitManagerEvent('manager:package-root-changed', { root })
+    }
+  }
+
+  _emitManagerEvent(name, payload = {}) {
+    try {
+      const result = this.hooks.emit(name, payload, this.getContext())
+      if (isPromiseLike(result)) {
+        result.catch((error) => {
+          console.warn('[PluginManager] Failed to dispatch manager event:', name, error)
+        })
+      }
+    } catch (error) {
+      console.warn('[PluginManager] Failed to notify manager event listeners:', name, error)
+    }
+  }
+
+  _notifyPluginStateChanged(name, action = 'update') {
+    const plugin = this.plugins.get(name) ?? null
+    this._emitManagerEvent('manager:plugins-changed', {
+      name,
+      action,
+      plugin
+    })
+  }
+
+  async _resolvePackageDirectory(packageState = {}) {
+    if (!packageState) return null
+    if (packageState.directoryName) {
+      const root = await this.getPackageRootDirectory()
+      if (root) {
+        return joinPathSegments(root, packageState.directoryName)
+      }
+    }
+    return packageState.directory ?? null
+  }
+
+  async _getPluginPackageMeta(name) {
+    const definition = this.moduleSources.get(name)
+    const storedState = this.settingsStore?.getState(name) ?? null
+    const storedPackage = storedState?.package ?? null
+    let directoryName = storedPackage?.directoryName ?? definition?.meta?.packageDirName ?? null
+    if (!directoryName) {
+      const fallback = storedPackage?.directory ?? definition?.meta?.packageDir ?? null
+      const derived = extractDirectoryName(fallback)
+      if (derived) {
+        directoryName = derived
+        if (storedPackage) {
+          const nextPackage = { ...storedPackage, directoryName }
+          this.settingsStore?.setState(name, { package: nextPackage })
+        }
+      }
+    }
+
+    let directory = definition?.meta?.packageDir ?? null
+    if (directoryName) {
+      const root = await this.getPackageRootDirectory()
+      if (root) {
+        directory = joinPathSegments(root, directoryName)
+      }
+    }
+    if (!directory && storedPackage?.directory) {
+      directory = storedPackage.directory
+    }
+
+    if (definition?.meta) {
+      definition.meta.packageDirName = directoryName ?? definition.meta.packageDirName ?? null
+      if (directory) {
+        definition.meta.packageDir = directory
+      }
+    }
+
+    return { directory, directoryName, storedPackage }
+  }
+
+  async _persistPackageToDisk(name, files, entryPath) {
+    const bridge = this._getPluginBridge()
+    if (!bridge?.installPackage) return null
+    try {
+      const payload = {
+        name,
+        entry: sanitizeRelativePath(entryPath),
+        files: []
+      }
+      files.forEach((value, filePath) => {
+        const data = value instanceof Uint8Array ? value : new Uint8Array(value ?? [])
+        payload.files.push({
+          path: sanitizeRelativePath(filePath),
+          data: uint8ToBase64(data)
+        })
+      })
+      const result = await bridge.installPackage(payload)
+      if (result?.root) {
+        this._notePackageRoot(result.root)
+      }
+      return result ?? null
+    } catch (error) {
+      console.error('[PluginManager] 保存插件包至磁盘失败:', error)
+      return null
+    }
+  }
+
+  async _removePackageFromDisk(directory) {
+    if (!directory) return
+    const bridge = this._getPluginBridge()
+    if (!bridge?.removePackage) return
+    try {
+      await bridge.removePackage({ directory })
+    } catch (error) {
+      console.error('[PluginManager] 删除磁盘中的插件包失败:', error)
+    }
+  }
+
+  async _readPackageFileFromDisk(directory, filePath, options = {}) {
+    if (!directory || !filePath) return null
+    const bridge = this._getPluginBridge()
+    if (!bridge?.readFile) return null
+    try {
+      const normalized = sanitizeRelativePath(filePath)
+      return await bridge.readFile({ directory, path: normalized, encoding: options.encoding })
+    } catch (error) {
+      console.error('[PluginManager] 读取插件文件失败:', error)
+      return null
+    }
+  }
+
+  async _listPackageFilesFromDisk(directory) {
+    if (!directory) return []
+    const bridge = this._getPluginBridge()
+    if (!bridge?.listFiles) return []
+    try {
+      const list = await bridge.listFiles({ directory })
+      if (Array.isArray(list)) {
+        return list.map((item) => sanitizeRelativePath(item))
+      }
+    } catch (error) {
+      console.error('[PluginManager] 列出插件文件失败:', error)
+    }
+    return []
+  }
+
+  _normalizeSettingsEntry(plugin) {
+    const entry = {
+      label: '插件设置',
+      open: null,
+      route: null,
+      path: null,
+      href: null,
+      hasEntry: false
+    }
+    if (!plugin || typeof plugin !== 'object') {
+      return entry
+    }
+
+    const { settingsLabel } = plugin
+    if (typeof settingsLabel === 'string' && settingsLabel.trim()) {
+      entry.label = settingsLabel.trim()
+    }
+
+    const candidate = plugin.settings
+    if (typeof candidate === 'function') {
+      entry.open = candidate
+    } else if (candidate && typeof candidate === 'object') {
+      const { label, open, route, path, href } = candidate
+      if (typeof label === 'string' && label.trim()) {
+        entry.label = label.trim()
+      }
+      if (typeof open === 'function') {
+        entry.open = open
+      }
+      if (route) {
+        entry.route = route
+      }
+      if (path) {
+        entry.path = path
+      }
+      if (href) {
+        entry.href = href
+      }
+    }
+
+    if (typeof plugin.openSettings === 'function') {
+      entry.open = plugin.openSettings
+    }
+
+    entry.hasEntry = Boolean(entry.open || entry.route || entry.path || entry.href)
+    return entry
+  }
+
+  loadFromModules(modules) {
+    Object.entries(modules).forEach(([source, mod]) => {
+      const plugin = mod?.default ?? mod?.plugin ?? mod
+      if (!plugin) {
+        console.warn(`[PluginManager] Module "${source}" did not export a plugin.`)
+        return
+      }
+      this.registerPlugin(plugin, source, { origin: 'module' })
+    })
+  }
+
+  registerPlugin(plugin, source = 'inline', meta = {}) {
+    if (!plugin || typeof plugin !== 'object') {
+      console.warn('[PluginManager] Attempted to register invalid plugin:', plugin)
+      return
+    }
+    const manifest = meta?.manifest ?? null
+    const displayName = meta?.displayName ?? manifest?.displayName
+    const description = meta?.description ?? manifest?.description
+    const version = meta?.version ?? manifest?.version
+    const origin = meta?.origin ?? 'module'
+
+    const name = plugin.name ?? manifest?.name ?? source
+    if (!name) {
+      console.warn('[PluginManager] Plugin is missing a name and cannot be registered.', plugin)
+      return
+    }
+    if (this.plugins.has(name)) {
+      console.warn(`[PluginManager] Plugin "${name}" is already registered.`)
+      return
+    }
+    const storedState = this.settingsStore?.getState(name)
+    const storedPackage = storedState?.package ?? null
+    const experimentalAck = storedState?.experimentalAck === true || plugin.experimentalAck === true
+    const packageDirName = meta?.packageDirName
+      ?? storedPackage?.directoryName
+      ?? extractDirectoryName(meta?.packageDir ?? storedPackage?.directory ?? '')
+    this.moduleSources.set(name, {
+      plugin,
+      source,
+      meta: {
+        origin,
+        manifest,
+        files: meta?.files ?? null,
+        url: meta?.url ?? null,
+        packageDir: meta?.packageDir ?? storedPackage?.directory ?? null,
+        packageDirName: packageDirName ?? null,
+        packageEntry: meta?.packageEntry ?? storedPackage?.entry ?? null
+      }
+    })
+    if (storedState?.removed) {
+      return
+    }
+    const enabled = storedState?.enabled ?? (plugin.enabled !== false)
+    this.plugins.set(name, {
+      ...plugin,
+      name,
+      displayName: plugin.displayName ?? displayName ?? name,
+      description: plugin.description ?? description ?? '',
+      version: plugin.version ?? version ?? null,
+      origin,
+      enabled,
+      source,
+      isActive: false,
+      teardown: null,
+      removable: (meta?.removable ?? plugin.removable) !== false,
+      experimentalAck
+    })
+    this._notifyPluginStateChanged(name, 'register')
+    if (this.settingsStore) {
+      this.settingsStore.setState(name, {
+        enabled,
+        removed: false,
+        experimentalAck
+      })
+    }
+    if (origin === 'package' && meta?.url) {
+      this.packageUrls.set(name, meta.url)
+    }
+  }
+
+  getPlugin(name) {
+    return this.plugins.get(name) ?? null
+  }
+
+  listPlugins() {
+    return Array.from(this.plugins.values()).map((plugin) => {
+      const { teardown, ...meta } = plugin
+      return {
+        ...meta,
+        settingsEntry: this._normalizeSettingsEntry(plugin)
+      }
+    })
+  }
+
+  listPluginAssets(name) {
+    const definition = this.moduleSources.get(name)
+    const files = definition?.meta?.files
+    if (!files) return []
+    if (files instanceof Map) {
+      return Array.from(files.keys())
+    }
+    if (files instanceof Set) {
+      return Array.from(files.values())
+    }
+    if (Array.isArray(files)) {
+      return files.map((item) => normalizePackagePath(item))
+    }
+    return []
+  }
+
+  async readPluginAsset(name, path, options = {}) {
+    if (!name || !path) return null
+    await this.ensurePackagesRestored()
+    const definition = this.moduleSources.get(name)
+    if (!definition || definition.meta?.origin !== 'package') return null
+    const files = definition.meta?.files
+    const normalized = normalizePackagePath(path)
+    let hasFile = false
+    if (files instanceof Map) {
+      hasFile = files.has(normalized)
+    } else if (files instanceof Set) {
+      hasFile = files.has(normalized)
+    } else if (Array.isArray(files)) {
+      hasFile = files.includes(normalized)
+    }
+    if (!hasFile) return null
+
+    const { directory } = await this._getPluginPackageMeta(name)
+
+    if (directory) {
+      const encoding = options.type === 'json' ? 'text' : options.type === 'base64' || options.type === 'arrayBuffer' ? 'base64' : 'text'
+      const payload = await this._readPackageFileFromDisk(directory, normalized, { encoding })
+      if (payload == null) return null
+      if (options.type === 'arrayBuffer') {
+        const bytes = typeof payload === 'string' ? base64ToUint8(payload) : new Uint8Array([])
+        return bytes.buffer
+      }
+      if (options.type === 'json') {
+        return JSON.parse(payload)
+      }
+      if (options.type === 'base64') {
+        if (typeof payload === 'string') return payload
+        return null
+      }
+      if (typeof payload === 'string') {
+        return payload
+      }
+      return null
+    }
+
+    if (!(files instanceof Map)) {
+      return null
+    }
+    const file = files.get(normalized)
+    if (!file) return null
+    const view = file instanceof Uint8Array ? file : new Uint8Array(file)
+    if (options.type === 'arrayBuffer') {
+      return view.slice().buffer
+    }
+    if (options.type === 'json') {
+      return JSON.parse(readText(view))
+    }
+    if (options.type === 'base64') {
+      return arrayBufferToBase64(view.buffer.slice(view.byteOffset, view.byteOffset + view.byteLength))
+    }
+    return readText(view)
+  }
+
+  _createAssetHelpers(name) {
+    return {
+      list: () => this.listPluginAssets(name),
+      has: (path) => {
+        const normalized = normalizePackagePath(path)
+        const definition = this.moduleSources.get(name)
+        return Boolean(definition?.meta?.files?.has(normalized))
+      },
+      read: (path, options) => this.readPluginAsset(name, path, options)
+    }
+  }
+
+  getContext() {
+    return {
+      app: this.app,
+      router: this.router,
+      pinia: this.pinia,
+      manager: this,
+      hooks: {
+        on: this.hooks.on.bind(this.hooks),
+        off: this.hooks.off.bind(this.hooks),
+        emit: (name, payload) => this.emitHook(name, payload)
+      }
+    }
+  }
+
+  async emitHook(name, payload) {
+    return this.hooks.emit(name, payload, this.getContext())
+  }
+
+  async activatePlugin(name) {
+    const plugin = this.plugins.get(name)
+    if (!plugin) {
+      console.warn(`[PluginManager] Plugin "${name}" was not found.`)
+      return
+    }
+    if (plugin.isActive) return
+    if (plugin.enabled === false) return
+    if (typeof plugin.setup !== 'function') {
+      console.warn(`[PluginManager] Plugin "${name}" does not provide a setup function.`)
+      plugin.isActive = true
+      return
+    }
+    try {
+      const context = {
+        ...this.getContext(),
+        plugin,
+        assets: this._createAssetHelpers(name)
+      }
+      const teardown = await plugin.setup(context)
+      if (typeof teardown === 'function') {
+        plugin.teardown = teardown
+      }
+      plugin.isActive = true
+    } catch (error) {
+      console.error(`[PluginManager] Failed to activate plugin "${name}":`, error)
+    }
+  }
+
+  async deactivatePlugin(name) {
+    const plugin = this.plugins.get(name)
+    if (!plugin || !plugin.isActive) return
+    if (typeof plugin.teardown === 'function') {
+      try {
+        await plugin.teardown()
+      } catch (error) {
+        console.error(`[PluginManager] Failed to teardown plugin "${name}":`, error)
+      }
+    }
+    plugin.isActive = false
+  }
+
+  async installAll() {
+    await this.ensurePackagesRestored()
+    const plugins = Array.from(this.plugins.values())
+    for (const plugin of plugins) {
+      if (plugin.enabled === false) continue
+      await this.activatePlugin(plugin.name)
+    }
+  }
+
+  async enablePlugin(name) {
+    await this.ensurePackagesRestored()
+    let plugin = this.plugins.get(name)
+    if (!plugin) {
+      plugin = this.restorePlugin(name)
+    }
+    if (plugin) {
+      plugin.enabled = true
+      this.settingsStore?.setState(name, { enabled: true, removed: false })
+      await this.activatePlugin(name)
+      this._notifyPluginStateChanged(name, 'enable')
+      return
+    }
+    this.settingsStore?.setState(name, { enabled: true, removed: false })
+    this._notifyPluginStateChanged(name, 'enable')
+  }
+
+  async disablePlugin(name) {
+    await this.ensurePackagesRestored()
+    let plugin = this.plugins.get(name)
+    if (!plugin) {
+      plugin = this.restorePlugin(name)
+    }
+    if (plugin) {
+      plugin.enabled = false
+      this.settingsStore?.setState(name, { enabled: false, removed: false })
+      await this.deactivatePlugin(name)
+      this._notifyPluginStateChanged(name, 'disable')
+      return
+    }
+    this.settingsStore?.setState(name, { enabled: false, removed: false })
+    this._notifyPluginStateChanged(name, 'disable')
+  }
+
+  async acknowledgePluginEnable(name) {
+    if (!name) return
+    await this.ensurePackagesRestored()
+    let plugin = this.plugins.get(name)
+    if (!plugin) {
+      plugin = this.restorePlugin(name)
+    }
+    if (plugin) {
+      plugin.experimentalAck = true
+    }
+    this.settingsStore?.setState(name, { experimentalAck: true })
+  }
+
+  async removePlugin(name, { forgetState = false } = {}) {
+    await this.ensurePackagesRestored()
+    const plugin = this.plugins.get(name)
+    const definition = this.moduleSources.get(name)
+    if (plugin) {
+      if (plugin.removable === false) {
+        console.warn(`[PluginManager] Plugin "${name}" is not removable.`)
+        return
+      }
+      await this.deactivatePlugin(name)
+      this.plugins.delete(name)
+    }
+    if (this.settingsStore) {
+      if (forgetState) {
+        const stored = this.settingsStore.getState(name)
+        const packageMeta = await this._getPluginPackageMeta(name)
+        const packageDir = packageMeta.directory ?? stored?.package?.directory ?? null
+        this.settingsStore.deleteState(name)
+        if (definition?.meta?.url) {
+          try {
+            URL.revokeObjectURL(definition.meta.url)
+          } catch (_) {
+            // ignore
+          }
+          this.packageUrls.delete(name)
+        }
+        if (packageDir) {
+          await this._removePackageFromDisk(packageDir)
+        }
+        this.moduleSources.delete(name)
+      } else {
+        this.settingsStore.setState(name, { removed: true, enabled: false })
+      }
+    }
+    this._notifyPluginStateChanged(name, 'remove')
+  }
+
+  hasPluginSettings(name) {
+    const plugin = this.plugins.get(name)
+    if (!plugin) return false
+    const entry = this._normalizeSettingsEntry(plugin)
+    return entry.hasEntry
+  }
+
+  async openPluginSettings(name, options = {}) {
+    await this.ensurePackagesRestored()
+    const plugin = this.plugins.get(name)
+    if (!plugin) {
+      console.warn(`[PluginManager] Plugin "${name}" was not found.`)
+      return
+    }
+    const entry = this._normalizeSettingsEntry(plugin)
+    if (!entry.hasEntry) {
+      console.warn(`[PluginManager] Plugin "${name}" does not expose settings.`)
+      return
+    }
+    const context = {
+      ...this.getContext(),
+      plugin,
+      options,
+      assets: this._createAssetHelpers(name)
+    }
+    try {
+      if (typeof entry.open === 'function') {
+        return await entry.open(context)
+      }
+      if (entry.route && this.router) {
+        const target = typeof entry.route === 'function' ? entry.route(context) : entry.route
+        if (target) {
+          return await this.router.push(target)
+        }
+      }
+      if (entry.path && this.router) {
+        const target = typeof entry.path === 'function' ? entry.path(context) : entry.path
+        if (target) {
+          return await this.router.push(target)
+        }
+      }
+      if (entry.href && typeof window !== 'undefined') {
+        const target = typeof entry.href === 'function' ? entry.href(context) : entry.href
+        if (target) {
+          window.open(target, '_blank', 'noopener')
+        }
+      }
+    } catch (error) {
+      console.error(`[PluginManager] Failed to open settings for plugin "${name}":`, error)
+      throw error
+    }
+  }
+
+  async _loadPackageFromBuffer(arrayBuffer, nameHint = '') {
+    if (!arrayBuffer || arrayBuffer.byteLength === 0) {
+      throw new Error('插件包为空')
+    }
+    const files = await extractPackageEntries(arrayBuffer)
+    if (!files || files.size === 0) {
+      throw new Error('插件包不包含任何文件')
+    }
+
+    const manifestPath = normalizePackagePath(PACKAGE_MANIFEST_PATH)
+    if (!files.has(manifestPath)) {
+      throw new Error('插件包缺少 manifest.json 文件')
+    }
+    let manifest
+    try {
+      manifest = JSON.parse(readText(files.get(manifestPath)))
+    } catch (error) {
+      throw new Error('插件包的 manifest 无法解析，请确认 JSON 格式是否正确')
+    }
+    manifest = sanitizeManifest(manifest, nameHint)
+
+    const mainPath = normalizePackagePath(manifest.main ?? PACKAGE_DEFAULT_MAIN)
+    const entry = files.get(mainPath)
+    if (!entry) {
+      throw new Error(`插件包缺少入口文件 ${mainPath}`)
+    }
+
+    let pluginModule = null
+    let pluginDefinition = null
+    let objectUrl = null
+
+    if (mainPath.toLowerCase().endsWith('.json')) {
+      try {
+        pluginDefinition = JSON.parse(readText(entry))
+      } catch (error) {
+        throw new Error('入口 JSON 解析失败，请确认文件内容合法')
+      }
+      pluginModule = { default: pluginDefinition }
+    } else {
+      const code = readText(entry)
+      const blob = new Blob([code], { type: 'text/javascript' })
+      objectUrl = URL.createObjectURL(blob)
+      try {
+        pluginModule = await import(/* @vite-ignore */ `${objectUrl}#${Date.now()}`)
+      } catch (error) {
+        URL.revokeObjectURL(objectUrl)
+        throw error
+      }
+      pluginDefinition = pluginModule?.default ?? pluginModule?.plugin ?? pluginModule
+      if (!pluginDefinition || typeof pluginDefinition !== 'object') {
+        URL.revokeObjectURL(objectUrl)
+        throw new Error('入口文件未导出可用的插件对象')
+      }
+    }
+
+    let normalizedPlugin = pluginDefinition
+    const derivedName = manifest.name ?? nameHint ?? pluginDefinition?.name
+    if (!normalizedPlugin.name && derivedName) {
+      normalizedPlugin = { ...normalizedPlugin, name: derivedName }
+    }
+    if (!normalizedPlugin.displayName && manifest.displayName) {
+      normalizedPlugin = { ...normalizedPlugin, displayName: manifest.displayName }
+    }
+    if (!normalizedPlugin.description && manifest.description) {
+      normalizedPlugin = { ...normalizedPlugin, description: manifest.description }
+    }
+    if (!normalizedPlugin.version && manifest.version) {
+      normalizedPlugin = { ...normalizedPlugin, version: manifest.version }
+    }
+
+    const normalizedFiles = new Map()
+    files.forEach((value, key) => {
+      normalizedFiles.set(normalizePackagePath(key), value)
+    })
+
+    return {
+      manifest,
+      plugin: normalizedPlugin,
+      url: objectUrl,
+      files: normalizedFiles,
+      entry: mainPath,
+      fileList: Array.from(normalizedFiles.keys())
+    }
+  }
+
+  async _loadPackageFromDirectory(directory, manifest = {}, entryPath = PACKAGE_DEFAULT_MAIN, fileList = []) {
+    const normalizedEntry = normalizePackagePath(entryPath || PACKAGE_DEFAULT_MAIN)
+    const isJson = normalizedEntry.toLowerCase().endsWith('.json')
+    const raw = await this._readPackageFileFromDisk(directory, normalizedEntry, { encoding: 'text' })
+    if (raw == null) {
+      throw new Error(`无法读取插件入口文件 ${normalizedEntry}`)
+    }
+
+    let objectUrl = null
+    let pluginDefinition = null
+
+    if (isJson) {
+      try {
+        pluginDefinition = JSON.parse(raw)
+      } catch (error) {
+        throw new Error('入口 JSON 解析失败，请确认文件内容合法')
+      }
+    } else {
+      const blob = new Blob([raw], { type: 'text/javascript' })
+      objectUrl = URL.createObjectURL(blob)
+      try {
+        const pluginModule = await import(/* @vite-ignore */ `${objectUrl}#${Date.now()}`)
+        pluginDefinition = pluginModule?.default ?? pluginModule?.plugin ?? pluginModule
+      } catch (error) {
+        if (objectUrl) URL.revokeObjectURL(objectUrl)
+        throw error
+      }
+      if (!pluginDefinition || typeof pluginDefinition !== 'object') {
+        if (objectUrl) URL.revokeObjectURL(objectUrl)
+        throw new Error('入口文件未导出可用的插件对象')
+      }
+    }
+
+    let normalizedPlugin = pluginDefinition
+    const derivedName = manifest?.name ?? normalizedPlugin?.name
+    if (!normalizedPlugin.name && derivedName) {
+      normalizedPlugin = { ...normalizedPlugin, name: derivedName }
+    }
+    if (!normalizedPlugin.displayName && manifest?.displayName) {
+      normalizedPlugin = { ...normalizedPlugin, displayName: manifest.displayName }
+    }
+    if (!normalizedPlugin.description && manifest?.description) {
+      normalizedPlugin = { ...normalizedPlugin, description: manifest.description }
+    }
+    if (!normalizedPlugin.version && manifest?.version) {
+      normalizedPlugin = { ...normalizedPlugin, version: manifest.version }
+    }
+
+    const files = new Set(fileList.map((item) => normalizePackagePath(item)))
+
+    return {
+      manifest,
+      plugin: normalizedPlugin,
+      url: objectUrl,
+      files,
+      entry: normalizedEntry
+    }
+  }
+
+  async _registerPackageFromState(name, meta) {
+    const packageState = meta?.package
+    if (!packageState) return
+    if (this.plugins.has(name)) return
+    const normalizedState = { ...packageState }
+    if (!normalizedState.directoryName) {
+      const derived = extractDirectoryName(normalizedState.directory)
+      if (derived) {
+        normalizedState.directoryName = derived
+        this.settingsStore?.setState(name, { package: { ...normalizedState } })
+      }
+    }
+    let resolvedDirectory = null
+    if (normalizedState.directory || normalizedState.directoryName) {
+      resolvedDirectory = await this._resolvePackageDirectory(normalizedState)
+    }
+    if (resolvedDirectory) {
+      try {
+        const manifest = normalizedState.manifest ?? {}
+        const entryPath = normalizedState.entry ?? manifest.main ?? PACKAGE_DEFAULT_MAIN
+        const fileList = Array.isArray(normalizedState.files)
+          ? normalizedState.files
+          : await this._listPackageFilesFromDisk(resolvedDirectory)
+        const { plugin, url, files } = await this._loadPackageFromDirectory(
+          resolvedDirectory,
+          manifest,
+          entryPath,
+          fileList
+        )
+        this.registerPlugin(plugin, `package:${name}`, {
+          origin: 'package',
+          manifest,
+          files,
+          url,
+          displayName: manifest?.displayName,
+          description: manifest?.description,
+          version: manifest?.version,
+          packageDir: resolvedDirectory,
+          packageDirName: normalizedState.directoryName ?? extractDirectoryName(resolvedDirectory),
+          packageEntry: entryPath
+        })
+        return
+      } catch (error) {
+        console.error(`[PluginManager] 无法通过目录恢复插件 "${name}":`, error)
+        if (!normalizedState.archive) {
+          return
+        }
+      }
+    }
+
+    if (!normalizedState.archive) return
+    try {
+      const buffer = base64ToArrayBuffer(normalizedState.archive)
+      const { manifest, plugin, url, files, entry } = await this._loadPackageFromBuffer(buffer, name)
+      this.registerPlugin(plugin, `package:${name}`, {
+        origin: 'package',
+        manifest,
+        files,
+        url,
+        displayName: manifest?.displayName,
+        description: manifest?.description,
+        version: manifest?.version,
+        packageEntry: entry,
+        packageDir: null
+      })
+    } catch (error) {
+      console.error(`[PluginManager] 无法通过归档恢复插件 "${name}":`, error)
+    }
+  }
+
+  async _restorePersistedPackages({ force = false } = {}) {
+    if (this._restorePackagesPromise && !force) {
+      return this._restorePackagesPromise
+    }
+    const task = (async () => {
+      await this.getPackageRootDirectory().catch(() => null)
+      const state = this.settingsStore?.list?.() ?? {}
+      const entries = Object.entries(state)
+      for (const [name, meta] of entries) {
+        const packageState = meta?.package
+        if (!packageState) continue
+        if (!packageState.archive && !packageState.directory && !packageState.directoryName) continue
+        if (this.plugins.has(name)) continue
+        await this._registerPackageFromState(name, meta)
+      }
+    })()
+    this._restorePackagesPromise = task
+    try {
+      await task
+    } catch (error) {
+      console.error('[PluginManager] 恢复插件包时发生错误:', error)
+    }
+    return this._restorePackagesPromise
+  }
+
+  async ensurePackagesRestored() {
+    if (!this._restorePackagesPromise) {
+      this._restorePackagesPromise = this._restorePersistedPackages()
+    }
+    return this._restorePackagesPromise
+  }
+
+  async importPluginPackage(file, options = {}) {
+    if (!file) {
+      throw new Error('未选择插件包')
+    }
+    const fileName = file.name ?? ''
+    if (fileName && !fileName.toLowerCase().endsWith(PACKAGE_EXTENSION)) {
+      throw new Error('仅支持导入 .hym 插件包')
+    }
+
+    const buffer = await file.arrayBuffer()
+    const nameHint = fileName ? fileName.replace(new RegExp(`${PACKAGE_EXTENSION}$`, 'i'), '') : ''
+    const { manifest, plugin, url, files, entry, fileList } = await this._loadPackageFromBuffer(buffer, nameHint)
+    const pluginName = plugin?.name ?? manifest?.name ?? nameHint
+
+    if (!pluginName) {
+      if (url) URL.revokeObjectURL(url)
+      throw new Error('插件包缺少 name 字段')
+    }
+
+    if (this.plugins.has(pluginName) || this.moduleSources.has(pluginName)) {
+      if (url) URL.revokeObjectURL(url)
+      throw new Error(`插件 "${pluginName}" 已存在，请先删除后再导入`)
+    }
+
+    const diskSnapshot = await this._persistPackageToDisk(pluginName, files, entry)
+    const packageState = {
+      entry,
+      files: fileList,
+      manifest,
+      filename: fileName,
+      importedAt: Date.now()
+    }
+    if (diskSnapshot?.directory) {
+      packageState.directory = diskSnapshot.directory
+    }
+    if (diskSnapshot?.directoryName) {
+      packageState.directoryName = diskSnapshot.directoryName
+    }
+    if (!packageState.directoryName && packageState.directory) {
+      packageState.directoryName = extractDirectoryName(packageState.directory)
+    }
+    if (diskSnapshot?.directory == null) {
+      packageState.archive = arrayBufferToBase64(buffer)
+    }
+    const enabledDefault = options.enable ?? (manifest?.enabled ?? plugin.enabled !== false)
+
+    this.settingsStore?.setState(pluginName, {
+      enabled: enabledDefault,
+      removed: false,
+      package: packageState
+    })
+
+    this.registerPlugin(plugin, `package:${pluginName}`, {
+      origin: 'package',
+      manifest,
+      files: diskSnapshot?.directory ? new Set(fileList) : files,
+      url,
+      displayName: manifest?.displayName,
+      description: manifest?.description,
+      version: manifest?.version,
+      packageDir: diskSnapshot?.directory ?? null,
+      packageDirName: diskSnapshot?.directoryName ?? packageState.directoryName ?? null,
+      packageEntry: entry
+    })
+
+    if (!enabledDefault) {
+      await this.disablePlugin(pluginName)
+      return this.getPlugin(pluginName)
+    }
+
+    if (options.activate === false) {
+      return this.getPlugin(pluginName)
+    }
+
+    await this.enablePlugin(pluginName)
+    return this.getPlugin(pluginName)
+  }
+
+  async setPackageRootDirectory(directory) {
+    if (!directory) {
+      throw new Error('请选择有效的目录')
+    }
+    const bridge = this._getPluginBridge()
+    if (!bridge?.setRoot) {
+      throw new Error('当前环境不支持自定义插件目录')
+    }
+    let result
+    try {
+      result = await bridge.setRoot({ directory })
+    } catch (error) {
+      console.error('[PluginManager] 设置插件存储目录失败:', error)
+      throw error
+    }
+    const root = result?.directory ?? directory
+    this._notePackageRoot(root)
+    const moved = Array.isArray(result?.moved) ? result.moved : []
+    const movedMap = new Map()
+    moved.forEach((item) => {
+      if (item?.from && item?.to) {
+        movedMap.set(normalizeComparablePath(item.from), item.to)
+      }
+    })
+
+    if (this.settingsStore) {
+      const state = this.settingsStore.list()
+      Object.entries(state).forEach(([name, meta]) => {
+        const pkg = meta?.package
+        if (!pkg) return
+        const nextPackage = { ...pkg }
+        if (!nextPackage.directoryName) {
+          const derived = extractDirectoryName(nextPackage.directory)
+          if (derived) {
+            nextPackage.directoryName = derived
+          }
+        }
+        if (nextPackage.directoryName && root) {
+          nextPackage.directory = joinPathSegments(root, nextPackage.directoryName)
+        } else if (nextPackage.directory) {
+          const migrated = movedMap.get(normalizeComparablePath(nextPackage.directory))
+          if (migrated) {
+            nextPackage.directory = migrated
+            nextPackage.directoryName = extractDirectoryName(migrated) || nextPackage.directoryName
+          }
+        }
+        this.settingsStore.setState(name, { package: nextPackage })
+      })
+    }
+
+    this.moduleSources.forEach((definition, pluginName) => {
+      if (definition.meta?.origin !== 'package') return
+      const stored = this.settingsStore?.getState(pluginName)
+      const pkg = stored?.package ?? {}
+      const directoryName =
+        pkg.directoryName ??
+        definition.meta?.packageDirName ??
+        extractDirectoryName(pkg.directory ?? definition.meta?.packageDir ?? '')
+      if (definition.meta) {
+        definition.meta.packageDirName = directoryName ?? null
+        if (root && directoryName) {
+          definition.meta.packageDir = joinPathSegments(root, directoryName)
+        } else if (pkg.directory) {
+          definition.meta.packageDir = pkg.directory
+        }
+      }
+    })
+
+    await this._restorePersistedPackages({ force: true })
+    const state = this.settingsStore?.list?.() ?? {}
+    for (const [name, meta] of Object.entries(state)) {
+      if (meta.removed) continue
+      if (meta.enabled) {
+        await this.enablePlugin(name)
+      }
+    }
+
+    return root
+  }
+
+  restorePlugin(name) {
+    if (!name) return null
+    const stored = this.settingsStore?.getState(name)
+    if (stored?.removed) {
+      this.settingsStore.setState(name, { removed: false })
+    }
+    if (this.plugins.has(name)) return this.plugins.get(name)
+    const definition = this.moduleSources.get(name)
+    if (definition) {
+      this.registerPlugin(definition.plugin, definition.source, definition.meta)
+      return this.plugins.get(name) ?? null
+    }
+    return null
+  }
+
+  exportSettings() {
+    return this.settingsStore?.export() ?? { plugins: {} }
+  }
+
+  async importSettings(payload, options = {}) {
+    const { merge = true, syncActivation = true } = options
+    this.settingsStore?.import(payload, { merge })
+    await this._restorePersistedPackages({ force: true })
+    if (!syncActivation) return
+    const state = this.settingsStore?.list() ?? {}
+    await Promise.all(
+      Object.entries(state).map(async ([name, meta]) => {
+        if (meta.removed) {
+          await this.removePlugin(name)
+          return
+        }
+        if (meta.enabled) {
+          await this.enablePlugin(name)
+        } else {
+          await this.disablePlugin(name)
+        }
+      })
+    )
+  }
+}
+
+const pluginModules = import.meta.glob('./modules/**/*.js', { eager: true })
+
+export function createPluginManager(app, options = {}) {
+  const manager = new PluginManager(app, options)
+  manager.loadFromModules(pluginModules)
+  return manager
+}

--- a/src/plugins/views/AudioEffectsSettings.vue
+++ b/src/plugins/views/AudioEffectsSettings.vue
@@ -1,0 +1,385 @@
+<template>
+  <div class="plugin-settings-page">
+    <header class="plugin-settings-header">
+      <button class="back-button" type="button" @click="goBack">
+        <span>返回</span>
+      </button>
+      <div class="header-meta">
+        <h1>音效增强</h1>
+        <p>通过提升低频、高频、存在感与空间混响，为播放带来更具层次感的声音表现。</p>
+      </div>
+    </header>
+
+    <section class="plugin-card" v-if="state.available">
+      <div class="plugin-option">
+        <div class="plugin-option-name">启用音效增强</div>
+        <div class="plugin-option-control">
+          <button class="button button--toggle" type="button" @click="toggleBypass">
+            {{ state.bypass ? '已关闭' : '已开启' }}
+          </button>
+        </div>
+      </div>
+
+      <div class="plugin-divider"></div>
+
+      <div class="plugin-option-list" :class="{ 'is-disabled': state.bypass }">
+        <div class="plugin-option">
+          <div class="plugin-option-name">低音增强</div>
+          <div class="plugin-option-control">
+            <input
+              class="slider"
+              type="range"
+              min="-12"
+              max="12"
+              step="1"
+              :value="state.bass"
+              @input="onBassChange($event.target.value)"
+            />
+            <span class="option-value">{{ displayDb(state.bass) }}</span>
+          </div>
+        </div>
+
+        <div class="plugin-option">
+          <div class="plugin-option-name">存在感增强</div>
+          <div class="plugin-option-control">
+            <input
+              class="slider"
+              type="range"
+              min="-12"
+              max="12"
+              step="1"
+              :value="state.presence"
+              @input="onPresenceChange($event.target.value)"
+            />
+            <span class="option-value">{{ displayDb(state.presence) }}</span>
+          </div>
+        </div>
+
+        <div class="plugin-option">
+          <div class="plugin-option-name">高音增强</div>
+          <div class="plugin-option-control">
+            <input
+              class="slider"
+              type="range"
+              min="-12"
+              max="12"
+              step="1"
+              :value="state.treble"
+              @input="onTrebleChange($event.target.value)"
+            />
+            <span class="option-value">{{ displayDb(state.treble) }}</span>
+          </div>
+        </div>
+
+        <div class="plugin-option">
+          <div class="plugin-option-name">立体声宽度</div>
+          <div class="plugin-option-control">
+            <input
+              class="slider"
+              type="range"
+              min="0"
+              max="2"
+              step="0.05"
+              :value="state.stereoWidth"
+              @input="onWidthChange($event.target.value)"
+            />
+            <span class="option-value">{{ displayWidth(state.stereoWidth) }}</span>
+          </div>
+        </div>
+
+        <div class="plugin-option">
+          <div class="plugin-option-name">空间混响</div>
+          <div class="plugin-option-control">
+            <input
+              class="slider"
+              type="range"
+              min="0"
+              max="1"
+              step="0.05"
+              :value="state.ambience"
+              @input="onAmbienceChange($event.target.value)"
+            />
+            <span class="option-value">{{ displayPercent(state.ambience) }}</span>
+          </div>
+        </div>
+
+        <div class="plugin-option">
+          <div class="plugin-option-name">输出增益</div>
+          <div class="plugin-option-control">
+            <input
+              class="slider"
+              type="range"
+              min="-12"
+              max="6"
+              step="0.5"
+              :value="state.outputGain"
+              @input="onOutputGainChange($event.target.value)"
+            />
+            <span class="option-value">{{ displayDb(state.outputGain) }}</span>
+          </div>
+        </div>
+      </div>
+
+      <div class="plugin-divider"></div>
+
+      <div class="reset-row">
+        <button class="button" type="button" @click="reset">恢复默认</button>
+        <span class="hint">默认设置提供轻微的现场感，可在此基础上微调至喜好的音色。</span>
+      </div>
+    </section>
+
+    <section class="plugin-card plugin-card--unavailable" v-else>
+      <h2>当前环境暂不支持</h2>
+      <p>检测到当前浏览器或运行环境未启用 Web Audio，暂无法使用音效增强功能。</p>
+    </section>
+  </div>
+</template>
+
+<script setup>
+import { useRouter } from 'vue-router'
+import {
+  audioEffectsState,
+  resetAudioEffects,
+  setAudioEffectsAmbience,
+  setAudioEffectsBass,
+  setAudioEffectsBypass,
+  setAudioEffectsOutputGain,
+  setAudioEffectsPresence,
+  setAudioEffectsStereoWidth,
+  setAudioEffectsTreble
+} from '../modules/audioEffectsPlugin'
+
+const state = audioEffectsState
+const router = useRouter()
+
+const goBack = () => {
+  router.push('/settings')
+}
+
+const toggleBypass = () => {
+  setAudioEffectsBypass(!state.bypass)
+}
+
+const onBassChange = (value) => {
+  setAudioEffectsBass(Number(value))
+}
+
+const onPresenceChange = (value) => {
+  setAudioEffectsPresence(Number(value))
+}
+
+const onTrebleChange = (value) => {
+  setAudioEffectsTreble(Number(value))
+}
+
+const onWidthChange = (value) => {
+  setAudioEffectsStereoWidth(Number(value))
+}
+
+const onAmbienceChange = (value) => {
+  setAudioEffectsAmbience(Number(value))
+}
+
+const onOutputGainChange = (value) => {
+  setAudioEffectsOutputGain(Number(value))
+}
+
+const reset = () => {
+  resetAudioEffects()
+}
+
+const displayDb = (value) => {
+  if (!Number.isFinite(Number(value))) return '0 dB'
+  const numeric = Math.round(Number(value) * 10) / 10
+  const prefix = numeric > 0 ? '+' : ''
+  return `${prefix}${numeric} dB`
+}
+
+const displayPercent = (value) => {
+  if (!Number.isFinite(Number(value))) return '0%'
+  return `${Math.round(Number(value) * 100)}%`
+}
+
+const displayWidth = (value) => {
+  if (!Number.isFinite(Number(value))) return '100%'
+  return `${Math.round(Number(value) * 100)}%`
+}
+</script>
+
+<style scoped>
+.plugin-settings-page {
+  padding: 32px 28px;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  color: #000;
+}
+
+.plugin-settings-header {
+  display: flex;
+  align-items: flex-start;
+  gap: 16px;
+}
+
+.back-button {
+  border: none;
+  background: rgba(0, 0, 0, 0.08);
+  color: #000;
+  font-family: SourceHanSansCN-Bold;
+  font-size: 14px;
+  padding: 8px 18px;
+  border-radius: 999px;
+  cursor: pointer;
+  transition: 0.2s;
+}
+
+.back-button:hover {
+  opacity: 0.85;
+  box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.35);
+}
+
+.header-meta {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.header-meta h1 {
+  margin: 0;
+  font-size: 28px;
+  font-family: SourceHanSansCN-Bold;
+}
+
+.header-meta p {
+  margin: 0;
+  font-size: 14px;
+  line-height: 1.7;
+  color: rgba(0, 0, 0, 0.65);
+}
+
+.plugin-card {
+  background: rgba(255, 255, 255, 0.6);
+  box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.04);
+  border-radius: 20px;
+  padding: 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.plugin-option-list {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.plugin-option {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.plugin-option-name {
+  font-size: 16px;
+  font-family: SourceHanSansCN-Bold;
+  min-width: 140px;
+}
+
+.plugin-option-control {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex: 1;
+  justify-content: flex-end;
+}
+
+.slider {
+  width: 260px;
+}
+
+.option-value {
+  min-width: 68px;
+  text-align: right;
+  font-size: 13px;
+  color: rgba(0, 0, 0, 0.6);
+}
+
+.button {
+  border: none;
+  background: rgba(0, 0, 0, 0.08);
+  color: #000;
+  font-family: SourceHanSansCN-Bold;
+  font-size: 14px;
+  padding: 8px 20px;
+  border-radius: 999px;
+  cursor: pointer;
+  transition: 0.2s;
+}
+
+.button:hover {
+  opacity: 0.85;
+  box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.35);
+}
+
+.button--toggle {
+  min-width: 148px;
+}
+
+.plugin-divider {
+  height: 1px;
+  width: 100%;
+  background: rgba(0, 0, 0, 0.08);
+}
+
+.reset-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.hint {
+  font-size: 12px;
+  color: rgba(0, 0, 0, 0.55);
+}
+
+.plugin-card--unavailable {
+  align-items: flex-start;
+  gap: 12px;
+}
+
+.plugin-card--unavailable h2 {
+  margin: 0;
+  font-size: 18px;
+  font-family: SourceHanSansCN-Bold;
+}
+
+.plugin-card--unavailable p {
+  margin: 0;
+  font-size: 14px;
+  color: rgba(0, 0, 0, 0.6);
+  line-height: 1.6;
+}
+
+.is-disabled {
+  opacity: 0.45;
+  pointer-events: none;
+}
+
+@media (max-width: 768px) {
+  .plugin-settings-page {
+    padding: 24px 16px;
+  }
+
+  .plugin-option-control {
+    justify-content: flex-start;
+  }
+
+  .slider {
+    width: 200px;
+  }
+}
+</style>

--- a/src/plugins/views/LyricVisualizerSettings.vue
+++ b/src/plugins/views/LyricVisualizerSettings.vue
@@ -1,0 +1,1242 @@
+<template>
+  <div class="lv-wrapper">
+    <header class="lv-header">
+      <button class="lv-back" type="button" @click="goBack">
+        <span>返回</span>
+      </button>
+      <div class="lv-header-text">
+        <h1 class="lv-title">歌词音频可视化</h1>
+        <p class="lv-description">
+          启用后将在歌词区域绘制实时频谱，可自定义柱状或圆环样式及相关参数。
+        </p>
+      </div>
+    </header>
+    <section class="lv-section">
+      <div class="lv-option">
+        <div class="lv-option-label">开启可视化</div>
+        <div class="lv-option-control">
+          <div class="lv-toggle" @click="toggleLyricVisualizer">
+            <div class="lv-toggle-off" :class="{ 'lv-toggle-on-in': playerStore.lyricVisualizer }">
+              {{ playerStore.lyricVisualizer ? '已开启' : '已关闭' }}
+            </div>
+            <Transition name="lv-toggle">
+              <div class="lv-toggle-on" v-show="playerStore.lyricVisualizer"></div>
+            </Transition>
+          </div>
+        </div>
+      </div>
+
+      <Transition name="lv-collapse">
+        <div v-if="playerStore.lyricVisualizer" class="lv-options-group">
+          <div class="lv-option">
+            <div class="lv-option-label">可视化样式</div>
+            <div class="lv-option-control lv-option-control--with-reset">
+              <div class="lv-selector-wrapper">
+                <Selector v-model="playerStore.lyricVisualizerStyle" :options="lyricVisualizerStyleOptions" />
+              </div>
+              <button class="lv-reset" type="button" @click="resetLyricVisualizerStyle">重置</button>
+            </div>
+          </div>
+
+          <div
+            class="lv-option"
+            v-if="playerStore.lyricVisualizerStyle === 'radial'"
+          >
+            <div class="lv-option-label">圆环大小</div>
+            <div class="lv-option-control lv-option-control--with-input">
+              <div class="lv-selector-wrapper">
+                <Selector
+                  v-model="playerStore.lyricVisualizerRadialSize"
+                  :options="lyricVisualizerRadialSizeOptions"
+                />
+              </div>
+              <div class="lv-add-group">
+                <input
+                  type="number"
+                  min="10"
+                  v-model="lyricVisualizerRadialSizeCustom"
+                  @keyup.enter="addLyricVisualizerRadialSizeOption"
+                />
+                <button
+                  type="button"
+                  class="lv-add"
+                  :class="{ 'lv-add--remove': lyricVisualizerRadialSizeAction.mode === 'remove' }"
+                  @click="addLyricVisualizerRadialSizeOption"
+                >
+                  {{ lyricVisualizerRadialSizeAction.mode === 'remove' ? '删除' : '添加' }}
+                </button>
+              </div>
+              <button class="lv-reset" type="button" @click="resetLyricVisualizerRadialSize">重置</button>
+            </div>
+          </div>
+
+          <div
+            class="lv-option"
+            v-if="playerStore.lyricVisualizerStyle === 'radial'"
+          >
+            <div class="lv-option-label">X 轴偏移</div>
+            <div class="lv-option-control lv-option-control--with-input">
+              <div class="lv-selector-wrapper">
+                <Selector
+                  v-model="playerStore.lyricVisualizerRadialOffsetX"
+                  :options="lyricVisualizerRadialOffsetXOptions"
+                />
+              </div>
+              <div class="lv-add-group">
+                <input
+                  type="number"
+                  v-model="lyricVisualizerRadialOffsetXCustom"
+                  @keyup.enter="addLyricVisualizerRadialOffsetXOption"
+                />
+                <button
+                  type="button"
+                  class="lv-add"
+                  :class="{ 'lv-add--remove': lyricVisualizerRadialOffsetXAction.mode === 'remove' }"
+                  @click="addLyricVisualizerRadialOffsetXOption"
+                >
+                  {{ lyricVisualizerRadialOffsetXAction.mode === 'remove' ? '删除' : '添加' }}
+                </button>
+              </div>
+              <button class="lv-reset" type="button" @click="resetLyricVisualizerRadialOffsetX">重置</button>
+            </div>
+          </div>
+
+          <div
+            class="lv-option"
+            v-if="playerStore.lyricVisualizerStyle === 'radial'"
+          >
+            <div class="lv-option-label">Y 轴偏移</div>
+            <div class="lv-option-control lv-option-control--with-input">
+              <div class="lv-selector-wrapper">
+                <Selector
+                  v-model="playerStore.lyricVisualizerRadialOffsetY"
+                  :options="lyricVisualizerRadialOffsetYOptions"
+                />
+              </div>
+              <div class="lv-add-group">
+                <input
+                  type="number"
+                  v-model="lyricVisualizerRadialOffsetYCustom"
+                  @keyup.enter="addLyricVisualizerRadialOffsetYOption"
+                />
+                <button
+                  type="button"
+                  class="lv-add"
+                  :class="{ 'lv-add--remove': lyricVisualizerRadialOffsetYAction.mode === 'remove' }"
+                  @click="addLyricVisualizerRadialOffsetYOption"
+                >
+                  {{ lyricVisualizerRadialOffsetYAction.mode === 'remove' ? '删除' : '添加' }}
+                </button>
+              </div>
+              <button class="lv-reset" type="button" @click="resetLyricVisualizerRadialOffsetY">重置</button>
+            </div>
+          </div>
+
+          <div class="lv-option">
+            <div class="lv-option-label">可视化高度</div>
+            <div class="lv-option-control lv-option-control--with-input">
+              <div class="lv-selector-wrapper">
+                <Selector v-model="playerStore.lyricVisualizerHeight" :options="lyricVisualizerHeightOptions" />
+              </div>
+              <div class="lv-add-group">
+                <input
+                  type="number"
+                  min="1"
+                  v-model="lyricVisualizerHeightCustom"
+                  @keyup.enter="addLyricVisualizerHeightOption"
+                />
+                <button
+                  type="button"
+                  class="lv-add"
+                  :class="{ 'lv-add--remove': lyricVisualizerHeightAction.mode === 'remove' }"
+                  @click="addLyricVisualizerHeightOption"
+                >
+                  {{ lyricVisualizerHeightAction.mode === 'remove' ? '删除' : '添加' }}
+                </button>
+              </div>
+              <button class="lv-reset" type="button" @click="resetLyricVisualizerHeight">重置</button>
+            </div>
+          </div>
+
+          <div class="lv-option">
+            <div class="lv-option-label">柱体数量</div>
+            <div class="lv-option-control lv-option-control--with-input">
+              <div class="lv-selector-wrapper">
+                <Selector v-model="playerStore.lyricVisualizerBarCount" :options="lyricVisualizerBarCountOptions" />
+              </div>
+              <div class="lv-add-group">
+                <input
+                  type="number"
+                  min="1"
+                  v-model="lyricVisualizerBarCountCustom"
+                  @keyup.enter="addLyricVisualizerBarCountOption"
+                />
+                <button
+                  type="button"
+                  class="lv-add"
+                  :class="{ 'lv-add--remove': lyricVisualizerBarCountAction.mode === 'remove' }"
+                  @click="addLyricVisualizerBarCountOption"
+                >
+                  {{ lyricVisualizerBarCountAction.mode === 'remove' ? '删除' : '添加' }}
+                </button>
+              </div>
+              <button class="lv-reset" type="button" @click="resetLyricVisualizerBarCount">重置</button>
+            </div>
+          </div>
+
+          <div class="lv-option">
+            <div class="lv-option-label">柱体宽度</div>
+            <div class="lv-option-control lv-option-control--with-input">
+              <div class="lv-selector-wrapper">
+                <Selector v-model="playerStore.lyricVisualizerBarWidth" :options="lyricVisualizerBarWidthOptions" />
+              </div>
+              <div class="lv-add-group">
+                <input
+                  type="number"
+                  min="1"
+                  v-model="lyricVisualizerBarWidthCustom"
+                  @keyup.enter="addLyricVisualizerBarWidthOption"
+                />
+                <button
+                  type="button"
+                  class="lv-add"
+                  :class="{ 'lv-add--remove': lyricVisualizerBarWidthAction.mode === 'remove' }"
+                  @click="addLyricVisualizerBarWidthOption"
+                >
+                  {{ lyricVisualizerBarWidthAction.mode === 'remove' ? '删除' : '添加' }}
+                </button>
+              </div>
+              <button class="lv-reset" type="button" @click="resetLyricVisualizerBarWidth">重置</button>
+            </div>
+          </div>
+
+          <div class="lv-option">
+            <div class="lv-option-label">频率范围</div>
+            <div class="lv-option-control lv-option-control--range">
+              <div class="lv-option-subgroup">
+                <span class="lv-option-subgroup-label">最低</span>
+                <div class="lv-selector-wrapper">
+                  <Selector
+                    v-model="playerStore.lyricVisualizerFrequencyMin"
+                    :options="lyricVisualizerFrequencyMinOptions"
+                  />
+                </div>
+                <div class="lv-add-group">
+                  <input
+                    type="number"
+                    min="20"
+                    v-model="lyricVisualizerFrequencyMinCustom"
+                    @keyup.enter="addLyricVisualizerFrequencyMinOption"
+                  />
+                  <button
+                    type="button"
+                    class="lv-add"
+                    :class="{ 'lv-add--remove': lyricVisualizerFrequencyMinAction.mode === 'remove' }"
+                    @click="addLyricVisualizerFrequencyMinOption"
+                  >
+                    {{ lyricVisualizerFrequencyMinAction.mode === 'remove' ? '删除' : '添加' }}
+                  </button>
+                </div>
+                <button class="lv-reset" type="button" @click="resetLyricVisualizerFrequencyMin">重置</button>
+              </div>
+              <div class="lv-option-subgroup">
+                <span class="lv-option-subgroup-label">最高</span>
+                <div class="lv-selector-wrapper">
+                  <Selector
+                    v-model="playerStore.lyricVisualizerFrequencyMax"
+                    :options="lyricVisualizerFrequencyMaxOptions"
+                  />
+                </div>
+                <div class="lv-add-group">
+                  <input
+                    type="number"
+                    min="20"
+                    v-model="lyricVisualizerFrequencyMaxCustom"
+                    @keyup.enter="addLyricVisualizerFrequencyMaxOption"
+                  />
+                  <button
+                    type="button"
+                    class="lv-add"
+                    :class="{ 'lv-add--remove': lyricVisualizerFrequencyMaxAction.mode === 'remove' }"
+                    @click="addLyricVisualizerFrequencyMaxOption"
+                  >
+                    {{ lyricVisualizerFrequencyMaxAction.mode === 'remove' ? '删除' : '添加' }}
+                  </button>
+                </div>
+                <button class="lv-reset" type="button" @click="resetLyricVisualizerFrequencyMax">重置</button>
+              </div>
+            </div>
+          </div>
+
+          <div class="lv-option">
+            <div class="lv-option-label">可视化透明度</div>
+            <div class="lv-option-control lv-option-control--with-input">
+              <div class="lv-selector-wrapper">
+                <Selector
+                  v-model="playerStore.lyricVisualizerOpacity"
+                  :options="lyricVisualizerOpacityOptions"
+                />
+              </div>
+              <div class="lv-add-group">
+                <input
+                  type="number"
+                  min="0"
+                  max="100"
+                  v-model="lyricVisualizerOpacityCustom"
+                  @keyup.enter="addLyricVisualizerOpacityOption"
+                />
+                <button
+                  type="button"
+                  class="lv-add"
+                  :class="{ 'lv-add--remove': lyricVisualizerOpacityAction.mode === 'remove' }"
+                  @click="addLyricVisualizerOpacityOption"
+                >
+                  {{ lyricVisualizerOpacityAction.mode === 'remove' ? '删除' : '添加' }}
+                </button>
+              </div>
+              <button class="lv-reset" type="button" @click="resetLyricVisualizerOpacity">重置</button>
+            </div>
+          </div>
+
+          <div class="lv-option">
+            <div class="lv-option-label">可视化颜色</div>
+            <div class="lv-option-control">
+              <div class="lv-selector-wrapper">
+                <Selector v-model="playerStore.lyricVisualizerColor" :options="lyricVisualizerColorOptions" />
+              </div>
+            </div>
+          </div>
+
+          <div class="lv-option">
+            <div class="lv-option-label">过渡延迟</div>
+            <div class="lv-option-control lv-option-control--with-input">
+              <div class="lv-selector-wrapper">
+                <Selector
+                  v-model="playerStore.lyricVisualizerTransitionDelay"
+                  :options="lyricVisualizerTransitionDelayOptions"
+                />
+              </div>
+              <div class="lv-add-group">
+                <input
+                  type="number"
+                  step="0.01"
+                  min="0"
+                  max="0.95"
+                  v-model="lyricVisualizerTransitionDelayCustom"
+                  @keyup.enter="addLyricVisualizerTransitionDelayOption"
+                />
+                <button
+                  type="button"
+                  class="lv-add"
+                  :class="{ 'lv-add--remove': lyricVisualizerTransitionDelayAction.mode === 'remove' }"
+                  @click="addLyricVisualizerTransitionDelayOption"
+                >
+                  {{ lyricVisualizerTransitionDelayAction.mode === 'remove' ? '删除' : '添加' }}
+                </button>
+              </div>
+              <button class="lv-reset" type="button" @click="resetLyricVisualizerTransitionDelay">重置</button>
+            </div>
+          </div>
+        </div>
+      </Transition>
+    </section>
+  </div>
+</template>
+
+<script setup>
+import { computed, ref, watch } from 'vue'
+import { useRouter } from 'vue-router'
+import Selector from '../../components/Selector.vue'
+import { usePlayerStore } from '../../store/playerStore'
+import { lyricVisualizerDefaults } from '../modules/lyricVisualizerPlugin'
+
+const playerStore = usePlayerStore()
+const router = useRouter()
+
+const goBack = () => {
+  router.push('/settings')
+}
+
+const clampNumber = (value, min, max, fallback = min) => {
+  const numeric = Number(value)
+  if (!Number.isFinite(numeric)) return fallback
+  if (numeric < min) return min
+  if (numeric > max) return max
+  return numeric
+}
+
+const toDisplayNumber = (value, fractionDigits = 0) => {
+  if (!Number.isFinite(value)) return ''
+  if (fractionDigits <= 0) return String(Math.round(value))
+  return Number(value)
+    .toFixed(fractionDigits)
+    .replace(/\.0+$/, '')
+    .replace(/(\.\d*?)0+$/, '$1')
+}
+
+const formatOptionLabel = (value, unit, defaultValue, fractionDigits = 0) => {
+  const numberText = toDisplayNumber(value, fractionDigits)
+  return `${numberText}${unit}${value === defaultValue ? '（默认）' : ''}`
+}
+
+const addChoiceValue = (listRef, value) => {
+  if (!Number.isFinite(value)) return
+  if (!listRef.value.includes(value)) {
+    listRef.value = [...listRef.value, value].sort((a, b) => a - b)
+  }
+}
+
+const removeChoiceValue = (listRef, value) => {
+  if (!Number.isFinite(value)) return
+  listRef.value = listRef.value.filter((item) => item !== value)
+}
+
+const createCustomActionState = (inputRef, sanitizeFn, valuesRef) =>
+  computed(() => {
+    const raw = String(inputRef.value ?? '').trim()
+    if (!raw) {
+      return { mode: 'add', value: null, exists: false }
+    }
+    const safe = sanitizeFn(raw)
+    if (!Number.isFinite(safe)) {
+      return { mode: 'add', value: null, exists: false }
+    }
+    const exists = valuesRef.value.includes(safe)
+    return { mode: exists ? 'remove' : 'add', value: safe, exists }
+  })
+
+const sanitizeHeight = (value) => {
+  const numeric = Number(value)
+  if (!Number.isFinite(numeric)) return lyricVisualizerDefaults.height
+  return Math.max(1, Math.round(numeric))
+}
+
+const sanitizeFrequencyMin = (value) => {
+  const numeric = Number(value)
+  if (!Number.isFinite(numeric)) return lyricVisualizerDefaults.frequencyMin
+  return clampNumber(Math.round(numeric), 20, 20000, lyricVisualizerDefaults.frequencyMin)
+}
+
+const sanitizeFrequencyMax = (value) => {
+  const numeric = Number(value)
+  if (!Number.isFinite(numeric)) return lyricVisualizerDefaults.frequencyMax
+  return clampNumber(Math.round(numeric), 20, 20000, lyricVisualizerDefaults.frequencyMax)
+}
+
+const sanitizeFrequencyRange = (min, max) => {
+  let safeMin = sanitizeFrequencyMin(min)
+  let safeMax = sanitizeFrequencyMax(max)
+  if (safeMin >= safeMax) {
+    if (safeMin >= 19990) {
+      safeMin = 19990
+      safeMax = 20000
+    } else {
+      safeMax = Math.min(20000, safeMin + 10)
+    }
+  }
+  if (safeMax - safeMin < 10) {
+    if (safeMin >= 19990) {
+      safeMin = 19990
+      safeMax = 20000
+    } else {
+      safeMax = Math.min(20000, safeMin + 10)
+    }
+  }
+  return { min: safeMin, max: safeMax }
+}
+
+const sanitizeBarCount = (value) => {
+  const numeric = Number(value)
+  if (!Number.isFinite(numeric)) return lyricVisualizerDefaults.barCount
+  return Math.max(1, Math.round(numeric))
+}
+
+const sanitizeBarWidth = (value) => {
+  const numeric = Number(value)
+  if (!Number.isFinite(numeric)) return lyricVisualizerDefaults.barWidth
+  return Math.max(1, Math.round(numeric))
+}
+
+const sanitizeVisualizerStyle = (value) => {
+  if (value === 'radial') return 'radial'
+  return lyricVisualizerDefaults.style
+}
+
+const sanitizeOpacity = (value) => {
+  const numeric = Number(value)
+  if (!Number.isFinite(numeric)) return lyricVisualizerDefaults.opacity
+  return clampNumber(Math.round(numeric), 0, 100, lyricVisualizerDefaults.opacity)
+}
+
+const sanitizeTransitionDelay = (value) => {
+  const numeric = Number(value)
+  if (!Number.isFinite(numeric)) return lyricVisualizerDefaults.transitionDelay
+  return Math.round(clampNumber(numeric, 0, 0.95, lyricVisualizerDefaults.transitionDelay) * 100) / 100
+}
+
+const sanitizeRadialSize = (value) => {
+  const numeric = Number(value)
+  if (!Number.isFinite(numeric)) return lyricVisualizerDefaults.radialSize
+  return clampNumber(Math.round(numeric), 10, 400, lyricVisualizerDefaults.radialSize)
+}
+
+const sanitizeRadialOffset = (value) => {
+  const numeric = Number(value)
+  if (!Number.isFinite(numeric)) return 0
+  return clampNumber(Math.round(numeric), -100, 100, 0)
+}
+
+const lyricVisualizerHeightBaseValues = Object.freeze([160, 180, 200, 220, 260, 320])
+const lyricVisualizerBarCountBaseValues = Object.freeze([24, 32, 48, 64, 96])
+const lyricVisualizerBarWidthBaseValues = Object.freeze([35, 45, 55, 65, 75])
+const lyricVisualizerFrequencyMinBaseValues = Object.freeze([20, 40, 80, 120, 200])
+const lyricVisualizerFrequencyMaxBaseValues = Object.freeze([4000, 6000, 8000, 12000, 16000])
+const lyricVisualizerTransitionDelayBaseValues = Object.freeze([0, 0.25, 0.5, 0.75, 0.9])
+const lyricVisualizerOpacityBaseValues = Object.freeze([20, 40, 60, 80, 100])
+const lyricVisualizerRadialSizeBaseValues = Object.freeze([60, 80, 100, 120, 160])
+const lyricVisualizerRadialOffsetBaseValues = Object.freeze([-50, -25, 0, 25, 50])
+
+const lyricVisualizerHeightValues = ref([...lyricVisualizerHeightBaseValues])
+const lyricVisualizerBarCountValues = ref([...lyricVisualizerBarCountBaseValues])
+const lyricVisualizerBarWidthValues = ref([...lyricVisualizerBarWidthBaseValues])
+const lyricVisualizerFrequencyMinValues = ref([...lyricVisualizerFrequencyMinBaseValues])
+const lyricVisualizerFrequencyMaxValues = ref([...lyricVisualizerFrequencyMaxBaseValues])
+const lyricVisualizerTransitionDelayValues = ref([...lyricVisualizerTransitionDelayBaseValues])
+const lyricVisualizerOpacityValues = ref([...lyricVisualizerOpacityBaseValues])
+const lyricVisualizerRadialSizeValues = ref([...lyricVisualizerRadialSizeBaseValues])
+const lyricVisualizerRadialOffsetXValues = ref([...lyricVisualizerRadialOffsetBaseValues])
+const lyricVisualizerRadialOffsetYValues = ref([...lyricVisualizerRadialOffsetBaseValues])
+
+const lyricVisualizerStyleOptions = [
+  { label: '柱状条形（默认）', value: 'bars' },
+  { label: '辐射圆环', value: 'radial' }
+]
+
+const lyricVisualizerHeightOptions = computed(() =>
+  lyricVisualizerHeightValues.value.map((value) => ({
+    label: formatOptionLabel(value, 'px', lyricVisualizerDefaults.height),
+    value
+  }))
+)
+
+const lyricVisualizerBarCountOptions = computed(() =>
+  lyricVisualizerBarCountValues.value.map((value) => ({
+    label: formatOptionLabel(value, ' 个', lyricVisualizerDefaults.barCount),
+    value
+  }))
+)
+
+const lyricVisualizerBarWidthOptions = computed(() =>
+  lyricVisualizerBarWidthValues.value.map((value) => ({
+    label: formatOptionLabel(value, '', lyricVisualizerDefaults.barWidth),
+    value
+  }))
+)
+
+const lyricVisualizerFrequencyMinOptions = computed(() =>
+  lyricVisualizerFrequencyMinValues.value.map((value) => ({
+    label: formatOptionLabel(value, 'Hz', lyricVisualizerDefaults.frequencyMin),
+    value
+  }))
+)
+
+const lyricVisualizerFrequencyMaxOptions = computed(() =>
+  lyricVisualizerFrequencyMaxValues.value.map((value) => ({
+    label: formatOptionLabel(value, 'Hz', lyricVisualizerDefaults.frequencyMax),
+    value
+  }))
+)
+
+const lyricVisualizerTransitionDelayOptions = computed(() =>
+  lyricVisualizerTransitionDelayValues.value.map((value) => ({
+    label: formatOptionLabel(value, ' 秒', lyricVisualizerDefaults.transitionDelay, 2),
+    value
+  }))
+)
+
+const lyricVisualizerOpacityOptions = computed(() =>
+  lyricVisualizerOpacityValues.value.map((value) => ({
+    label: formatOptionLabel(value, '%', lyricVisualizerDefaults.opacity),
+    value
+  }))
+)
+
+const lyricVisualizerRadialSizeOptions = computed(() =>
+  lyricVisualizerRadialSizeValues.value.map((value) => ({
+    label: formatOptionLabel(value, '%', lyricVisualizerDefaults.radialSize),
+    value
+  }))
+)
+
+const lyricVisualizerRadialOffsetXOptions = computed(() =>
+  lyricVisualizerRadialOffsetXValues.value.map((value) => ({
+    label: formatOptionLabel(value, '%', lyricVisualizerDefaults.radialOffsetX),
+    value
+  }))
+)
+
+const lyricVisualizerRadialOffsetYOptions = computed(() =>
+  lyricVisualizerRadialOffsetYValues.value.map((value) => ({
+    label: formatOptionLabel(value, '%', lyricVisualizerDefaults.radialOffsetY),
+    value
+  }))
+)
+
+const lyricVisualizerColorOptions = [
+  { label: '黑色（默认）', value: 'black' },
+  { label: '白色', value: 'white' }
+]
+
+const lyricVisualizerHeightCustom = ref('')
+const lyricVisualizerBarCountCustom = ref('')
+const lyricVisualizerBarWidthCustom = ref('')
+const lyricVisualizerFrequencyMinCustom = ref('')
+const lyricVisualizerFrequencyMaxCustom = ref('')
+const lyricVisualizerTransitionDelayCustom = ref('')
+const lyricVisualizerOpacityCustom = ref('')
+const lyricVisualizerRadialSizeCustom = ref('')
+const lyricVisualizerRadialOffsetXCustom = ref('')
+const lyricVisualizerRadialOffsetYCustom = ref('')
+
+const lyricVisualizerHeightAction = createCustomActionState(
+  lyricVisualizerHeightCustom,
+  sanitizeHeight,
+  lyricVisualizerHeightValues
+)
+const lyricVisualizerBarCountAction = createCustomActionState(
+  lyricVisualizerBarCountCustom,
+  sanitizeBarCount,
+  lyricVisualizerBarCountValues
+)
+const lyricVisualizerBarWidthAction = createCustomActionState(
+  lyricVisualizerBarWidthCustom,
+  sanitizeBarWidth,
+  lyricVisualizerBarWidthValues
+)
+const lyricVisualizerTransitionDelayAction = createCustomActionState(
+  lyricVisualizerTransitionDelayCustom,
+  sanitizeTransitionDelay,
+  lyricVisualizerTransitionDelayValues
+)
+const lyricVisualizerOpacityAction = createCustomActionState(
+  lyricVisualizerOpacityCustom,
+  sanitizeOpacity,
+  lyricVisualizerOpacityValues
+)
+const lyricVisualizerRadialSizeAction = createCustomActionState(
+  lyricVisualizerRadialSizeCustom,
+  sanitizeRadialSize,
+  lyricVisualizerRadialSizeValues
+)
+const lyricVisualizerRadialOffsetXAction = createCustomActionState(
+  lyricVisualizerRadialOffsetXCustom,
+  sanitizeRadialOffset,
+  lyricVisualizerRadialOffsetXValues
+)
+const lyricVisualizerRadialOffsetYAction = createCustomActionState(
+  lyricVisualizerRadialOffsetYCustom,
+  sanitizeRadialOffset,
+  lyricVisualizerRadialOffsetYValues
+)
+
+const lyricVisualizerFrequencyMinAction = computed(() => {
+  const raw = String(lyricVisualizerFrequencyMinCustom.value ?? '').trim()
+  if (!raw) return { mode: 'add', value: null, exists: false, pairedMax: null }
+  const { min, max } = sanitizeFrequencyRange(raw, playerStore.lyricVisualizerFrequencyMax)
+  if (!Number.isFinite(min)) return { mode: 'add', value: null, exists: false, pairedMax: null }
+  const exists = lyricVisualizerFrequencyMinValues.value.includes(min)
+  return { mode: exists ? 'remove' : 'add', value: min, exists, pairedMax: max }
+})
+
+const lyricVisualizerFrequencyMaxAction = computed(() => {
+  const raw = String(lyricVisualizerFrequencyMaxCustom.value ?? '').trim()
+  if (!raw) return { mode: 'add', value: null, exists: false, pairedMin: null }
+  const { min, max } = sanitizeFrequencyRange(playerStore.lyricVisualizerFrequencyMin, raw)
+  if (!Number.isFinite(max)) return { mode: 'add', value: null, exists: false, pairedMin: null }
+  const exists = lyricVisualizerFrequencyMaxValues.value.includes(max)
+  return { mode: exists ? 'remove' : 'add', value: max, exists, pairedMin: min }
+})
+
+const addLyricVisualizerHeightOption = () => {
+  const { mode, value } = lyricVisualizerHeightAction.value
+  if (value === null) return
+  if (mode === 'remove') {
+    removeChoiceValue(lyricVisualizerHeightValues, value)
+    if (playerStore.lyricVisualizerHeight === value) {
+      playerStore.lyricVisualizerHeight = lyricVisualizerDefaults.height
+    }
+  } else {
+    addChoiceValue(lyricVisualizerHeightValues, value)
+    playerStore.lyricVisualizerHeight = value
+  }
+  lyricVisualizerHeightCustom.value = ''
+}
+
+const addLyricVisualizerBarCountOption = () => {
+  const { mode, value } = lyricVisualizerBarCountAction.value
+  if (value === null) return
+  if (mode === 'remove') {
+    removeChoiceValue(lyricVisualizerBarCountValues, value)
+    if (playerStore.lyricVisualizerBarCount === value) {
+      playerStore.lyricVisualizerBarCount = lyricVisualizerDefaults.barCount
+    }
+  } else {
+    addChoiceValue(lyricVisualizerBarCountValues, value)
+    playerStore.lyricVisualizerBarCount = value
+  }
+  lyricVisualizerBarCountCustom.value = ''
+}
+
+const addLyricVisualizerBarWidthOption = () => {
+  const { mode, value } = lyricVisualizerBarWidthAction.value
+  if (value === null) return
+  if (mode === 'remove') {
+    removeChoiceValue(lyricVisualizerBarWidthValues, value)
+    if (playerStore.lyricVisualizerBarWidth === value) {
+      playerStore.lyricVisualizerBarWidth = lyricVisualizerDefaults.barWidth
+    }
+  } else {
+    addChoiceValue(lyricVisualizerBarWidthValues, value)
+    playerStore.lyricVisualizerBarWidth = value
+  }
+  lyricVisualizerBarWidthCustom.value = ''
+}
+
+const addLyricVisualizerFrequencyMinOption = () => {
+  const { mode, value, pairedMax } = lyricVisualizerFrequencyMinAction.value
+  if (value === null) return
+  if (mode === 'remove') {
+    removeChoiceValue(lyricVisualizerFrequencyMinValues, value)
+    if (playerStore.lyricVisualizerFrequencyMin === value) {
+      playerStore.lyricVisualizerFrequencyMin = lyricVisualizerDefaults.frequencyMin
+      playerStore.lyricVisualizerFrequencyMax = lyricVisualizerDefaults.frequencyMax
+    }
+  } else {
+    addChoiceValue(lyricVisualizerFrequencyMinValues, value)
+    if (Number.isFinite(pairedMax)) {
+      addChoiceValue(lyricVisualizerFrequencyMaxValues, pairedMax)
+      playerStore.lyricVisualizerFrequencyMax = pairedMax
+    }
+    playerStore.lyricVisualizerFrequencyMin = value
+  }
+  lyricVisualizerFrequencyMinCustom.value = ''
+}
+
+const addLyricVisualizerFrequencyMaxOption = () => {
+  const { mode, value, pairedMin } = lyricVisualizerFrequencyMaxAction.value
+  if (value === null) return
+  if (mode === 'remove') {
+    removeChoiceValue(lyricVisualizerFrequencyMaxValues, value)
+    if (playerStore.lyricVisualizerFrequencyMax === value) {
+      playerStore.lyricVisualizerFrequencyMin = lyricVisualizerDefaults.frequencyMin
+      playerStore.lyricVisualizerFrequencyMax = lyricVisualizerDefaults.frequencyMax
+    }
+  } else {
+    addChoiceValue(lyricVisualizerFrequencyMaxValues, value)
+    if (Number.isFinite(pairedMin)) {
+      addChoiceValue(lyricVisualizerFrequencyMinValues, pairedMin)
+      playerStore.lyricVisualizerFrequencyMin = pairedMin
+    }
+    playerStore.lyricVisualizerFrequencyMax = value
+  }
+  lyricVisualizerFrequencyMaxCustom.value = ''
+}
+
+const addLyricVisualizerTransitionDelayOption = () => {
+  const { mode, value } = lyricVisualizerTransitionDelayAction.value
+  if (value === null) return
+  if (mode === 'remove') {
+    removeChoiceValue(lyricVisualizerTransitionDelayValues, value)
+    if (playerStore.lyricVisualizerTransitionDelay === value) {
+      playerStore.lyricVisualizerTransitionDelay = lyricVisualizerDefaults.transitionDelay
+    }
+  } else {
+    addChoiceValue(lyricVisualizerTransitionDelayValues, value)
+    playerStore.lyricVisualizerTransitionDelay = value
+  }
+  lyricVisualizerTransitionDelayCustom.value = ''
+}
+
+const addLyricVisualizerOpacityOption = () => {
+  const { mode, value } = lyricVisualizerOpacityAction.value
+  if (value === null) return
+  if (mode === 'remove') {
+    removeChoiceValue(lyricVisualizerOpacityValues, value)
+    if (playerStore.lyricVisualizerOpacity === value) {
+      playerStore.lyricVisualizerOpacity = lyricVisualizerDefaults.opacity
+    }
+  } else {
+    addChoiceValue(lyricVisualizerOpacityValues, value)
+    playerStore.lyricVisualizerOpacity = value
+  }
+  lyricVisualizerOpacityCustom.value = ''
+}
+
+const addLyricVisualizerRadialSizeOption = () => {
+  const { mode, value } = lyricVisualizerRadialSizeAction.value
+  if (value === null) return
+  if (mode === 'remove') {
+    removeChoiceValue(lyricVisualizerRadialSizeValues, value)
+    if (playerStore.lyricVisualizerRadialSize === value) {
+      playerStore.lyricVisualizerRadialSize = lyricVisualizerDefaults.radialSize
+    }
+  } else {
+    addChoiceValue(lyricVisualizerRadialSizeValues, value)
+    playerStore.lyricVisualizerRadialSize = value
+  }
+  lyricVisualizerRadialSizeCustom.value = ''
+}
+
+const addLyricVisualizerRadialOffsetXOption = () => {
+  const { mode, value } = lyricVisualizerRadialOffsetXAction.value
+  if (value === null) return
+  if (mode === 'remove') {
+    removeChoiceValue(lyricVisualizerRadialOffsetXValues, value)
+    if (playerStore.lyricVisualizerRadialOffsetX === value) {
+      playerStore.lyricVisualizerRadialOffsetX = lyricVisualizerDefaults.radialOffsetX
+    }
+  } else {
+    addChoiceValue(lyricVisualizerRadialOffsetXValues, value)
+    playerStore.lyricVisualizerRadialOffsetX = value
+  }
+  lyricVisualizerRadialOffsetXCustom.value = ''
+}
+
+const addLyricVisualizerRadialOffsetYOption = () => {
+  const { mode, value } = lyricVisualizerRadialOffsetYAction.value
+  if (value === null) return
+  if (mode === 'remove') {
+    removeChoiceValue(lyricVisualizerRadialOffsetYValues, value)
+    if (playerStore.lyricVisualizerRadialOffsetY === value) {
+      playerStore.lyricVisualizerRadialOffsetY = lyricVisualizerDefaults.radialOffsetY
+    }
+  } else {
+    addChoiceValue(lyricVisualizerRadialOffsetYValues, value)
+    playerStore.lyricVisualizerRadialOffsetY = value
+  }
+  lyricVisualizerRadialOffsetYCustom.value = ''
+}
+
+const resetLyricVisualizerStyle = () => {
+  playerStore.lyricVisualizerStyle = lyricVisualizerDefaults.style
+}
+
+const resetLyricVisualizerHeight = () => {
+  playerStore.lyricVisualizerHeight = lyricVisualizerDefaults.height
+}
+
+const resetLyricVisualizerBarCount = () => {
+  playerStore.lyricVisualizerBarCount = lyricVisualizerDefaults.barCount
+}
+
+const resetLyricVisualizerBarWidth = () => {
+  playerStore.lyricVisualizerBarWidth = lyricVisualizerDefaults.barWidth
+}
+
+const resetLyricVisualizerFrequencyMin = () => {
+  playerStore.lyricVisualizerFrequencyMin = lyricVisualizerDefaults.frequencyMin
+}
+
+const resetLyricVisualizerFrequencyMax = () => {
+  playerStore.lyricVisualizerFrequencyMax = lyricVisualizerDefaults.frequencyMax
+}
+
+const resetLyricVisualizerTransitionDelay = () => {
+  playerStore.lyricVisualizerTransitionDelay = lyricVisualizerDefaults.transitionDelay
+}
+
+const resetLyricVisualizerOpacity = () => {
+  playerStore.lyricVisualizerOpacity = lyricVisualizerDefaults.opacity
+}
+
+const resetLyricVisualizerRadialSize = () => {
+  playerStore.lyricVisualizerRadialSize = lyricVisualizerDefaults.radialSize
+}
+
+const resetLyricVisualizerRadialOffsetX = () => {
+  playerStore.lyricVisualizerRadialOffsetX = lyricVisualizerDefaults.radialOffsetX
+}
+
+const resetLyricVisualizerRadialOffsetY = () => {
+  playerStore.lyricVisualizerRadialOffsetY = lyricVisualizerDefaults.radialOffsetY
+}
+
+const toggleLyricVisualizer = () => {
+  playerStore.lyricVisualizer = !playerStore.lyricVisualizer
+}
+
+watch(
+  () => playerStore.lyricVisualizerHeight,
+  (value) => {
+    const safe = sanitizeHeight(value)
+    if (value !== safe) playerStore.lyricVisualizerHeight = safe
+    addChoiceValue(lyricVisualizerHeightValues, safe)
+  }
+)
+
+watch(
+  [() => playerStore.lyricVisualizerFrequencyMin, () => playerStore.lyricVisualizerFrequencyMax],
+  ([min, max]) => {
+    const { min: safeMin, max: safeMax } = sanitizeFrequencyRange(min, max)
+    if (min !== safeMin) playerStore.lyricVisualizerFrequencyMin = safeMin
+    if (max !== safeMax) playerStore.lyricVisualizerFrequencyMax = safeMax
+    addChoiceValue(lyricVisualizerFrequencyMinValues, safeMin)
+    addChoiceValue(lyricVisualizerFrequencyMaxValues, safeMax)
+  }
+)
+
+watch(
+  () => playerStore.lyricVisualizerBarCount,
+  (value) => {
+    const safe = sanitizeBarCount(value)
+    if (value !== safe) playerStore.lyricVisualizerBarCount = safe
+    addChoiceValue(lyricVisualizerBarCountValues, safe)
+  }
+)
+
+watch(
+  () => playerStore.lyricVisualizerBarWidth,
+  (value) => {
+    const safe = sanitizeBarWidth(value)
+    if (value !== safe) playerStore.lyricVisualizerBarWidth = safe
+    addChoiceValue(lyricVisualizerBarWidthValues, safe)
+  }
+)
+
+watch(
+  () => playerStore.lyricVisualizerStyle,
+  (value) => {
+    const safe = sanitizeVisualizerStyle(value)
+    if (value !== safe) playerStore.lyricVisualizerStyle = safe
+  }
+)
+
+watch(
+  () => playerStore.lyricVisualizerTransitionDelay,
+  (value) => {
+    const safe = sanitizeTransitionDelay(value)
+    if (value !== safe) playerStore.lyricVisualizerTransitionDelay = safe
+    addChoiceValue(lyricVisualizerTransitionDelayValues, safe)
+  }
+)
+
+watch(
+  () => playerStore.lyricVisualizerOpacity,
+  (value) => {
+    const safe = sanitizeOpacity(value)
+    if (value !== safe) playerStore.lyricVisualizerOpacity = safe
+    addChoiceValue(lyricVisualizerOpacityValues, safe)
+  }
+)
+
+watch(
+  () => playerStore.lyricVisualizerRadialSize,
+  (value) => {
+    const safe = sanitizeRadialSize(value)
+    if (value !== safe) playerStore.lyricVisualizerRadialSize = safe
+    addChoiceValue(lyricVisualizerRadialSizeValues, safe)
+  }
+)
+
+watch(
+  () => playerStore.lyricVisualizerRadialOffsetX,
+  (value) => {
+    const safe = sanitizeRadialOffset(value)
+    if (value !== safe) playerStore.lyricVisualizerRadialOffsetX = safe
+    addChoiceValue(lyricVisualizerRadialOffsetXValues, safe)
+  }
+)
+
+watch(
+  () => playerStore.lyricVisualizerRadialOffsetY,
+  (value) => {
+    const safe = sanitizeRadialOffset(value)
+    if (value !== safe) playerStore.lyricVisualizerRadialOffsetY = safe
+    addChoiceValue(lyricVisualizerRadialOffsetYValues, safe)
+  }
+)
+
+watch(
+  () => playerStore.lyricVisualizerColor,
+  (value) => {
+    if (!lyricVisualizerColorOptions.some((option) => option.value === value)) {
+      playerStore.lyricVisualizerColor = lyricVisualizerDefaults.color
+    }
+  }
+)
+</script>
+
+<style scoped>
+.lv-wrapper {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  padding: 24px;
+}
+
+.lv-header {
+  display: flex;
+  align-items: flex-start;
+  gap: 16px;
+}
+
+.lv-back {
+  border: none;
+  background: rgba(0, 0, 0, 0.08);
+  color: #000;
+  font-family: SourceHanSansCN-Bold;
+  font-size: 14px;
+  padding: 8px 18px;
+  border-radius: 999px;
+  cursor: pointer;
+  transition: 0.2s;
+}
+
+.lv-back:hover {
+  opacity: 0.85;
+  box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.35);
+}
+
+.lv-header-text {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.lv-title {
+  font-size: 24px;
+  font-family: SourceHanSansCN-Bold;
+  color: #000;
+}
+
+.lv-description {
+  font-size: 14px;
+  line-height: 1.6;
+  color: rgba(0, 0, 0, 0.65);
+}
+
+.lv-section {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.lv-option {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 16px;
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.55);
+  box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.04);
+}
+
+.lv-option-label {
+  font-size: 15px;
+  font-family: SourceHanSansCN-Bold;
+  color: #000;
+  min-width: 120px;
+}
+
+.lv-option-control {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex: 1;
+  justify-content: flex-end;
+}
+
+.lv-option-control--with-reset {
+  flex-wrap: wrap;
+}
+
+.lv-option-control--with-input {
+  flex-wrap: wrap;
+}
+
+.lv-option-control--range {
+  flex-direction: column;
+  align-items: stretch;
+  gap: 12px;
+}
+
+.lv-option-subgroup {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 12px;
+}
+
+.lv-option-subgroup-label {
+  font-size: 13px;
+  color: rgba(0, 0, 0, 0.65);
+  min-width: 36px;
+}
+
+.lv-selector-wrapper {
+  min-width: 160px;
+  max-width: 220px;
+}
+
+.lv-add-group {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.lv-add-group input {
+  width: 88px;
+  height: 34px;
+  border-radius: 8px;
+  border: none;
+  background: rgba(255, 255, 255, 0.75);
+  box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.08);
+  padding: 0 12px;
+  font-family: SourceHanSansCN-Bold;
+  font-size: 13px;
+  color: #000;
+  outline: none;
+}
+
+.lv-add {
+  height: 34px;
+  padding: 0 16px;
+  border-radius: 8px;
+  border: none;
+  background: rgba(0, 0, 0, 0.08);
+  color: #000;
+  font-size: 13px;
+  font-family: SourceHanSansCN-Bold;
+  cursor: pointer;
+  transition: 0.2s;
+}
+
+.lv-add:hover {
+  opacity: 0.85;
+  box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.4);
+}
+
+.lv-add--remove {
+  background: rgba(220, 53, 69, 0.12);
+  color: #d9253b;
+}
+
+.lv-add--remove:hover {
+  box-shadow: 0 0 0 1px rgba(217, 37, 59, 0.5);
+}
+
+.lv-reset {
+  height: 34px;
+  padding: 0 14px;
+  border-radius: 8px;
+  border: none;
+  background: rgba(0, 0, 0, 0.08);
+  color: #000;
+  font-size: 13px;
+  font-family: SourceHanSansCN-Bold;
+  cursor: pointer;
+  transition: 0.2s;
+}
+
+.lv-reset:hover {
+  opacity: 0.85;
+  box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.4);
+}
+
+.lv-toggle {
+  position: relative;
+  width: 160px;
+  height: 34px;
+  border-radius: 20px;
+  background: rgba(0, 0, 0, 0.12);
+  display: flex;
+  align-items: center;
+  padding: 4px;
+  box-sizing: border-box;
+  cursor: pointer;
+  transition: 0.2s;
+}
+
+.lv-toggle-off {
+  flex: 1;
+  text-align: center;
+  font-size: 13px;
+  font-family: SourceHanSansCN-Bold;
+  color: rgba(0, 0, 0, 0.6);
+  z-index: 1;
+}
+
+.lv-toggle-on {
+  position: absolute;
+  top: 4px;
+  bottom: 4px;
+  right: 4px;
+  width: calc(50% - 4px);
+  border-radius: 16px;
+  background: #000;
+}
+
+.lv-toggle-on-in {
+  color: #000;
+}
+
+.lv-toggle:hover {
+  box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.35);
+}
+
+.lv-options-group {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.lv-collapse-enter-active,
+.lv-collapse-leave-active {
+  transition: opacity 0.2s ease, transform 0.2s ease;
+}
+
+.lv-collapse-enter-from,
+.lv-collapse-leave-to {
+  opacity: 0;
+  transform: translateY(-6px);
+}
+
+.lv-toggle-enter-active,
+.lv-toggle-leave-active {
+  transition: transform 0.2s ease;
+}
+
+.lv-toggle-enter-from,
+.lv-toggle-leave-to {
+  transform: translateX(-50%);
+}
+
+@media (max-width: 768px) {
+  .lv-header {
+    flex-direction: column;
+    gap: 12px;
+  }
+
+  .lv-back {
+    align-self: flex-start;
+  }
+
+  .lv-wrapper {
+    padding: 16px;
+  }
+
+  .lv-option {
+    align-items: flex-start;
+  }
+
+  .lv-option-control {
+    justify-content: flex-start;
+  }
+
+  .lv-selector-wrapper {
+    width: 100%;
+  }
+}
+</style>


### PR DESCRIPTION
## Summary
- allow configuring the plugin storage root through the Electron IPC bridge so packages persist outside the app bundle
- emit manager-level plugin change events and react to them in the renderer so enable/disable/delete actions update immediately
- align the plugin settings section with other settings panels by awaiting refreshes, disabling configuration buttons for inactive plugins, and reacting to storage-path changes

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68e4ec54c2a48323b0387bd863defa37